### PR TITLE
Fix TypeError after calling set_text of UIButton

### DIFF
--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -152,6 +152,12 @@ class UIButton(UIElement):
         self.redraw()
 
     def compute_aligned_text_rect(self):
+        # render
+        if len(self.text) > 0:
+            self.text_surface = self.font.render(self.text, True, self.text_colour)
+        else:
+            self.text_surface = None
+
         self.aligned_text_rect = None
         if self.text_surface is not None:
             # horizontal

--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -120,48 +120,24 @@ class UIButton(UIElement):
 
         self.image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA)
 
-        text_horiz_alignment = self.ui_theme.get_misc_data(self.object_ids, self.element_ids, 'text_horiz_alignment')
+        self.text_horiz_alignment = self.ui_theme.get_misc_data(self.object_ids, self.element_ids, 'text_horiz_alignment')
         text_horiz_alignment_padding = self.ui_theme.get_misc_data(self.object_ids,
                                                                    self.element_ids, 'text_horiz_alignment_padding')
         if text_horiz_alignment_padding is None:
-            text_horiz_alignment_padding = 1
+            self.text_horiz_alignment_padding = 1
         else:
-            text_horiz_alignment_padding = int(text_horiz_alignment_padding)
+            self.text_horiz_alignment_padding = int(text_horiz_alignment_padding)
 
-        # this helps us draw the text aligned
-        self.aligned_text_rect = None
-        if self.text_surface is not None:
-            if text_horiz_alignment == 'center':
-                self.aligned_text_rect = self.text_surface.get_rect(centerx=self.rect.width/2)
-            elif text_horiz_alignment == 'left':
-                self.aligned_text_rect = self.text_surface.get_rect(x=text_horiz_alignment_padding
-                                                                    + self.shadow_width + self.border_width)
-            elif text_horiz_alignment == 'right':
-                x_pos = (self.click_area_shape.width - text_horiz_alignment_padding - self.text_surface.get_width()
-                         - self.shadow_width - self.border_width)
-                self.aligned_text_rect = self.text_surface.get_rect(x=x_pos)
-            else:
-                self.aligned_text_rect = self.text_surface.get_rect(centerx=self.rect.width/2)
-
-        text_vert_alignment = self.ui_theme.get_misc_data(self.object_ids, self.element_ids, 'text_vert_alignment')
+        self.text_vert_alignment = self.ui_theme.get_misc_data(self.object_ids, self.element_ids, 'text_vert_alignment')
         text_vert_alignment_padding = self.ui_theme.get_misc_data(self.object_ids,
                                                                   self.element_ids, 'text_vert_alignment_padding')
         if text_vert_alignment_padding is None:
-            text_vert_alignment_padding = 1
+            self.text_vert_alignment_padding = 1
         else:
-            text_vert_alignment_padding = int(text_vert_alignment_padding)
+            self.text_vert_alignment_padding = int(text_vert_alignment_padding)
 
-        if self.text_surface is not None:
-            if text_vert_alignment == 'center':
-                self.aligned_text_rect.centery = int(self.rect.height/2)
-            elif text_vert_alignment == 'top':
-                self.aligned_text_rect.y = (text_vert_alignment_padding + self.shadow_width + self.border_width)
-            elif text_vert_alignment == 'bottom':
-                self.aligned_text_rect.y = (self.rect.height - self.text_surface.get_height()
-                                            - text_vert_alignment_padding - self.shadow_width - self.border_width)
-            else:
-                self.aligned_text_rect.centery = int(self.rect.height/2)
-
+        # this helps us draw the text aligned
+        self.compute_aligned_text_rect()
         # default range at which we 'let go' of a button
         self.hold_range = (0, 0)
 
@@ -174,6 +150,32 @@ class UIButton(UIElement):
         self.set_any_images_from_theme()
 
         self.redraw()
+
+    def compute_aligned_text_rect(self):
+        self.aligned_text_rect = None
+        if self.text_surface is not None:
+            # horizontal
+            if self.text_horiz_alignment == 'center':
+                self.aligned_text_rect = self.text_surface.get_rect(centerx=self.rect.width/2)
+            elif self.text_horiz_alignment == 'left':
+                self.aligned_text_rect = self.text_surface.get_rect(x=self.text_horiz_alignment_padding
+                                                                    + self.shadow_width + self.border_width)
+            elif self.text_horiz_alignment == 'right':
+                x_pos = (self.click_area_shape.width - self.text_horiz_alignment_padding - self.text_surface.get_width()
+                         - self.shadow_width - self.border_width)
+                self.aligned_text_rect = self.text_surface.get_rect(x=x_pos)
+            else:
+                self.aligned_text_rect = self.text_surface.get_rect(centerx=self.rect.width/2)
+            # vertical
+            if self.text_vert_alignment == 'center':
+                self.aligned_text_rect.centery = int(self.rect.height/2)
+            elif self.text_vert_alignment == 'top':
+                self.aligned_text_rect.y = (self.text_vert_alignment_padding + self.shadow_width + self.border_width)
+            elif self.text_vert_alignment == 'bottom':
+                self.aligned_text_rect.y = (self.rect.height - self.text_surface.get_height()
+                                            - self.text_vert_alignment_padding - self.shadow_width - self.border_width)
+            else:
+                self.aligned_text_rect.centery = int(self.rect.height/2)
 
     def set_any_images_from_theme(self):
         """
@@ -485,6 +487,8 @@ class UIButton(UIElement):
         :param text: The new text to set.
         """
         self.text = text
+        # recompute aligned_text_rect before redraw
+        self.compute_aligned_text_rect()
         self.redraw()
 
     def set_hold_range(self, xy_range: Tuple[int, int]):


### PR DESCRIPTION
I found a bug when I test the following code:
```python
import pygame
import pygame_gui

pygame.init()
pygame.display.set_caption('Quick Start')
window_surface = pygame.display.set_mode((800, 600))
background = pygame.Surface((800, 600))
background.fill(pygame.Color('#000000'))
manager = pygame_gui.UIManager((800, 600))
# create a button with a empty text
hello_button = pygame_gui.elements.UIButton(relative_rect=pygame.Rect((350, 275), (100, 50)),
                                            text='',
                                            manager=manager)

clock = pygame.time.Clock()
is_running = True

while is_running:
        time_delta = clock.tick(60)/1000.0
        for event in pygame.event.get():
            if event.type == pygame.QUIT:
                is_running = False
            manager.process_events(event)
        manager.update(time_delta)
        window_surface.blit(background, (0, 0))
        manager.draw_ui(window_surface)
        pygame.display.update()
        # call set_text
        hello_button.set_text('hello')
```

Error message:
```
pygame 2.0.0.dev6 (SDL 2.0.10, python 3.7.4)
Hello from the pygame community. https://www.pygame.org/contribute.html
Traceback (most recent call last):
  File "test.py", line 29, in <module>
    hello_button.set_text('hello')
  File "/home/tau/Code/software/pygame_gui_examples/pygame_gui/elements/ui_button.py", line 488, in set_text
    self.redraw()
  File "/home/tau/Code/software/pygame_gui_examples/pygame_gui/elements/ui_button.py", line 407, in redraw
    self.image.blit(self.text_surface, self.aligned_text_rect)
TypeError: invalid destination position for blit
```
In the previous ui_button.py, aligned_text_rect is only be computed when the UIButton object is created. However, for different text, the aligned_text_rect should be different.
 I add a method called compute_aligned_text_rect method to recompute aligned_text_rect each time set_text is called.