### PR TITLE
Adds pre-multiplied alpha blending as default blitting operation for pygame 2.0.0.dev10+

### DIFF
--- a/.github/workflows/run_tests_ci.yml
+++ b/.github/workflows/run_tests_ci.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7]
-        pygame-version: [1.9.3, 1.9.6, 2.0.0.dev6]
+        pygame-version: [1.9.3, 1.9.6, 2.0.0.dev10]
         exclude:
           - {python-version: "3.6", pygame-version: "1.9.3"}
           - {python-version: "3.7", pygame-version: "1.9.3"}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   include:
     - os: osx
       language: generic
-      env: PYTHON=3.8.0 PYGAME_VERSION=2.0.0.dev6
+      env: PYTHON=3.8.0 PYGAME_VERSION=2.0.0.dev10
       before_install:
         - brew update
         - brew install openssl readline
@@ -52,29 +52,29 @@ jobs:
         - choco install python3 --params "/InstallDir:C:\\Python"
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python --version
-      env: PYGAME_VERSION=2.0.0.dev6
+      env: PYGAME_VERSION=2.0.0.dev10
     - os: linux
       python: 3.5
       env: PYGAME_VERSION=1.9.6
     - os: linux
       python: 3.5
-      env: PYGAME_VERSION=2.0.0.dev6
+      env: PYGAME_VERSION=2.0.0.dev10
     - os: linux
       python: 3.6
       env: PYGAME_VERSION=1.9.6
     - os: linux
       python: 3.6
-      env: PYGAME_VERSION=2.0.0.dev6
+      env: PYGAME_VERSION=2.0.0.dev10
     - os: linux
       python: 3.7
       env: PYGAME_VERSION=1.9.6
     - os: linux
       python: 3.7
-      env: PYGAME_VERSION=2.0.0.dev6
+      env: PYGAME_VERSION=2.0.0.dev10
     # No Travis version of 1.9.6 on Python 3.8 yet
     - os: linux
       python: 3.8
-      env: PYGAME_VERSION=2.0.0.dev6
+      env: PYGAME_VERSION=2.0.0.dev10
 
 install:
   - python -m pip install -U pip

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,9 +34,9 @@ copyright = '2019, Dan Lawrence'
 author = 'Dan Lawrence'
 
 # The short X.Y version
-version = '0.5.6'
+version = '0.5.7'
 # The full version, including alpha/beta/rc tags
-release = '0.5.6'
+release = '0.5.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,4 +2,4 @@ extraction:
   python:
     python_setup:
       requirements:
-        - pygame==2.0.0.dev8
+        - pygame==2.0.0.dev10

--- a/pygame_gui/core/drawable_shapes/drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/drawable_shape.py
@@ -6,6 +6,7 @@ import pygame
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.utility import render_white_text_alpha_black_bg, apply_colour_to_surface
+from pygame_gui.core.utility import basic_blit
 
 
 class DrawableShapeState:
@@ -18,7 +19,7 @@ class DrawableShapeState:
     def __init__(self, state_id: str):
 
         self.state_id = state_id
-        self.surface = pygame.Surface((0, 0))  # type: pygame.Surface
+        self.surface = pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)  # type: pygame.Surface
         self.has_fresh_surface = False
         self.cached_background_id = None  # type: Union[str, None]
         self.transition = None  # type: Union[DrawableStateTransition, None]
@@ -324,7 +325,7 @@ class DrawableShape:
         elif state_name in self.states and self.states['normal'].surface is not None:
             return self.states['normal'].surface
         else:
-            return pygame.Surface((0, 0))
+            return pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)
 
     def get_fresh_surface(self) -> pygame.Surface:
         """
@@ -368,8 +369,8 @@ class DrawableShape:
             image_rect = self.theming[image_state_str].get_rect()
             image_rect.center = (int(self.containing_rect.width / 2),
                                  int(self.containing_rect.height / 2))
-            self.states[state_str].surface.blit(self.theming[image_state_str], image_rect,
-                                                special_flags=pygame.BLEND_PREMULTIPLIED)
+            basic_blit(self.states[state_str].surface,
+                       self.theming[image_state_str], image_rect)
         # Draw any text
         if 'text' in self.theming and 'font' in self.theming and self.theming['text'] is not None:
             if len(self.theming['text']) > 0 and text_colour_state_str in self.theming:
@@ -387,26 +388,23 @@ class DrawableShape:
                                                                text=self.theming['text'])
                 apply_colour_to_surface(self.theming['text_shadow'], text_shadow)
 
-                self.states[state_str].surface.blit(text_shadow,
-                                                    (self.aligned_text_rect.x,
-                                                     self.aligned_text_rect.y + 1),
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
-                self.states[state_str].surface.blit(text_shadow,
-                                                    (self.aligned_text_rect.x,
-                                                     self.aligned_text_rect.y - 1),
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
-                self.states[state_str].surface.blit(text_shadow,
-                                                    (self.aligned_text_rect.x + 1,
-                                                     self.aligned_text_rect.y),
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
-                self.states[state_str].surface.blit(text_shadow,
-                                                    (self.aligned_text_rect.x - 1,
-                                                     self.aligned_text_rect.y),
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.states[state_str].surface, text_shadow,
+                           (self.aligned_text_rect.x,
+                            self.aligned_text_rect.y + 1))
+                basic_blit(self.states[state_str].surface, text_shadow,
+                           (self.aligned_text_rect.x,
+                            self.aligned_text_rect.y - 1))
+                basic_blit(self.states[state_str].surface, text_shadow,
+                           (self.aligned_text_rect.x + 1,
+                            self.aligned_text_rect.y))
+                basic_blit(self.states[state_str].surface, text_shadow,
+                           (self.aligned_text_rect.x - 1,
+                            self.aligned_text_rect.y))
 
             if text_surface is not None and self.aligned_text_rect is not None:
-                self.states[state_str].surface.blit(text_surface, self.aligned_text_rect,
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.states[state_str].surface,
+                           text_surface,
+                           self.aligned_text_rect)
 
     def redraw_state(self, state_str: str):
         """

--- a/pygame_gui/core/drawable_shapes/drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/drawable_shape.py
@@ -19,7 +19,7 @@ class DrawableShapeState:
     def __init__(self, state_id: str):
 
         self.state_id = state_id
-        self.surface = pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)  # type: pygame.Surface
+        self.surface = pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)
         self.has_fresh_surface = False
         self.cached_background_id = None  # type: Union[str, None]
         self.transition = None  # type: Union[DrawableStateTransition, None]

--- a/pygame_gui/core/drawable_shapes/drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/drawable_shape.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import deque, OrderedDict
 from typing import Dict, List, Union, Tuple
 
 import pygame
@@ -147,7 +147,7 @@ class DrawableShape:
         self.shadow_width = 0
         self.border_width = 0
 
-        self.states = {}
+        self.states = OrderedDict()
         for state in states:
             self.states[state] = DrawableShapeState(state)
 

--- a/pygame_gui/core/drawable_shapes/ellipse_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/ellipse_drawable_shape.py
@@ -6,7 +6,7 @@ import pygame
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape
-from pygame_gui.core.utility import apply_colour_to_surface
+from pygame_gui.core.utility import apply_colour_to_surface, basic_blit
 
 
 class EllipseDrawableShape(DrawableShape):
@@ -202,9 +202,7 @@ class EllipseDrawableShape(DrawableShape):
                                                                         clear=False)
                     apply_colour_to_surface(self.theming[border_colour_state_str],
                                             shape_surface)
-
-                bab_surface.blit(shape_surface, self.border_rect,
-                                 special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(bab_surface, shape_surface, self.border_rect)
             if isinstance(self.theming[bg_colour_state_str], ColourGradient):
                 shape_surface = self.clear_and_create_shape_surface(bab_surface,
                                                                     self.background_rect, 1,
@@ -216,8 +214,7 @@ class EllipseDrawableShape(DrawableShape):
                                                                     aa_amount=aa_amount)
                 apply_colour_to_surface(self.theming[bg_colour_state_str], shape_surface)
 
-            bab_surface.blit(shape_surface, self.background_rect,
-                             special_flags=pygame.BLEND_PREMULTIPLIED)
+            basic_blit(bab_surface, shape_surface, self.background_rect)
             # apply AA to background
             bab_surface = pygame.transform.smoothscale(bab_surface, self.containing_rect.size)
 
@@ -237,9 +234,7 @@ class EllipseDrawableShape(DrawableShape):
                                                                         self.shadow_width),
                                                                        sub_surface.get_size()),
                                                 special_flags=pygame.BLEND_RGBA_SUB)
-
-            self.states[state_str].surface.blit(bab_surface, (0, 0),
-                                                special_flags=pygame.BLEND_PREMULTIPLIED)
+            basic_blit(self.states[state_str].surface, bab_surface, (0, 0))
 
             if (shape_id is not None and
                     self.states[state_str].surface.get_width() <= 1024 and

--- a/pygame_gui/core/drawable_shapes/ellipse_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/ellipse_drawable_shape.py
@@ -6,6 +6,7 @@ import pygame
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape
+from pygame_gui.core.utility import apply_colour_to_surface
 
 
 class EllipseDrawableShape(DrawableShape):
@@ -70,6 +71,7 @@ class EllipseDrawableShape(DrawableShape):
             self.click_area_shape = self.containing_rect.copy()
             self.base_surface = pygame.Surface(self.containing_rect.size, flags=pygame.SRCALPHA,
                                                depth=32)
+            self.base_surface.fill(pygame.Color('#00000000'))
 
         self.compute_aligned_text_rect()
 
@@ -198,10 +200,11 @@ class EllipseDrawableShape(DrawableShape):
                                                                         self.border_rect,
                                                                         0, aa_amount=aa_amount,
                                                                         clear=False)
-                    self.apply_colour_to_surface(self.theming[border_colour_state_str],
-                                                 shape_surface)
+                    apply_colour_to_surface(self.theming[border_colour_state_str],
+                                            shape_surface)
 
-                bab_surface.blit(shape_surface, self.border_rect)
+                bab_surface.blit(shape_surface, self.border_rect,
+                                 special_flags=pygame.BLEND_PREMULTIPLIED)
             if isinstance(self.theming[bg_colour_state_str], ColourGradient):
                 shape_surface = self.clear_and_create_shape_surface(bab_surface,
                                                                     self.background_rect, 1,
@@ -211,9 +214,10 @@ class EllipseDrawableShape(DrawableShape):
                 shape_surface = self.clear_and_create_shape_surface(bab_surface,
                                                                     self.background_rect, 1,
                                                                     aa_amount=aa_amount)
-                self.apply_colour_to_surface(self.theming[bg_colour_state_str], shape_surface)
+                apply_colour_to_surface(self.theming[bg_colour_state_str], shape_surface)
 
-            bab_surface.blit(shape_surface, self.background_rect)
+            bab_surface.blit(shape_surface, self.background_rect,
+                             special_flags=pygame.BLEND_PREMULTIPLIED)
             # apply AA to background
             bab_surface = pygame.transform.smoothscale(bab_surface, self.containing_rect.size)
 
@@ -234,7 +238,8 @@ class EllipseDrawableShape(DrawableShape):
                                                                        sub_surface.get_size()),
                                                 special_flags=pygame.BLEND_RGBA_SUB)
 
-            self.states[state_str].surface.blit(bab_surface, (0, 0))
+            self.states[state_str].surface.blit(bab_surface, (0, 0),
+                                                special_flags=pygame.BLEND_PREMULTIPLIED)
 
             if (shape_id is not None and
                     self.states[state_str].surface.get_width() <= 1024 and
@@ -270,7 +275,7 @@ class EllipseDrawableShape(DrawableShape):
         # For the visible AA shape surface we only want to blend in the alpha channel
         large_shape_surface = pygame.Surface((rect.width, rect.height), flags=pygame.SRCALPHA,
                                              depth=32)
-        large_shape_surface.fill(pygame.Color('#FFFFFF00'))
+        large_shape_surface.fill(pygame.Color('#00000000'))
         pygame.draw.ellipse(large_shape_surface, pygame.Color("#FFFFFFFF"),
                             large_shape_surface.get_rect())
 

--- a/pygame_gui/core/drawable_shapes/rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rect_drawable_shape.py
@@ -7,6 +7,7 @@ import pygame
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape
+from pygame_gui.core.utility import basic_blit
 
 
 class RectDrawableShape(DrawableShape):
@@ -182,8 +183,8 @@ class RectDrawableShape(DrawableShape):
                                                         special_flags=pygame.BLEND_RGBA_SUB)
                     self.theming[border_colour_state_str].apply_gradient_to_surface(
                         border_shape_surface)
-                    self.states[state_str].surface.blit(border_shape_surface, self.border_rect,
-                                                        special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(self.states[state_str].surface,
+                               border_shape_surface, self.border_rect)
                 else:
                     self.states[state_str].surface.fill(self.theming[border_colour_state_str],
                                                         self.border_rect)
@@ -197,8 +198,8 @@ class RectDrawableShape(DrawableShape):
                                                     special_flags=pygame.BLEND_RGBA_SUB)
                 self.theming[bg_colour_state_str].apply_gradient_to_surface(
                     background_shape_surface)
-                self.states[state_str].surface.blit(background_shape_surface, self.background_rect,
-                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.states[state_str].surface,
+                           background_shape_surface, self.background_rect)
             else:
                 self.states[state_str].surface.fill(self.theming[bg_colour_state_str],
                                                     self.background_rect)
@@ -215,8 +216,8 @@ class RectDrawableShape(DrawableShape):
                     self.states[state_str].surface.blit(bar_shape_surface, bar_rect,
                                                         special_flags=pygame.BLEND_RGBA_SUB)
                     self.theming['filled_bar'].apply_gradient_to_surface(bar_shape_surface)
-                    self.states[state_str].surface.blit(bar_shape_surface, bar_rect,
-                                                        special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(self.states[state_str].surface,
+                               bar_shape_surface, bar_rect)
                 else:
                     self.states[state_str].surface.fill(self.theming['filled_bar'], bar_rect)
 

--- a/pygame_gui/core/drawable_shapes/rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rect_drawable_shape.py
@@ -182,7 +182,8 @@ class RectDrawableShape(DrawableShape):
                                                         special_flags=pygame.BLEND_RGBA_SUB)
                     self.theming[border_colour_state_str].apply_gradient_to_surface(
                         border_shape_surface)
-                    self.states[state_str].surface.blit(border_shape_surface, self.border_rect)
+                    self.states[state_str].surface.blit(border_shape_surface, self.border_rect,
+                                                        special_flags=pygame.BLEND_PREMULTIPLIED)
                 else:
                     self.states[state_str].surface.fill(self.theming[border_colour_state_str],
                                                         self.border_rect)
@@ -196,7 +197,8 @@ class RectDrawableShape(DrawableShape):
                                                     special_flags=pygame.BLEND_RGBA_SUB)
                 self.theming[bg_colour_state_str].apply_gradient_to_surface(
                     background_shape_surface)
-                self.states[state_str].surface.blit(background_shape_surface, self.background_rect)
+                self.states[state_str].surface.blit(background_shape_surface, self.background_rect,
+                                                    special_flags=pygame.BLEND_PREMULTIPLIED)
             else:
                 self.states[state_str].surface.fill(self.theming[bg_colour_state_str],
                                                     self.background_rect)
@@ -213,7 +215,8 @@ class RectDrawableShape(DrawableShape):
                     self.states[state_str].surface.blit(bar_shape_surface, bar_rect,
                                                         special_flags=pygame.BLEND_RGBA_SUB)
                     self.theming['filled_bar'].apply_gradient_to_surface(bar_shape_surface)
-                    self.states[state_str].surface.blit(bar_shape_surface, bar_rect)
+                    self.states[state_str].surface.blit(bar_shape_surface, bar_rect,
+                                                        special_flags=pygame.BLEND_PREMULTIPLIED)
                 else:
                     self.states[state_str].surface.fill(self.theming['filled_bar'], bar_rect)
 

--- a/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
@@ -8,6 +8,7 @@ from pygame.math import Vector2
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape
+from pygame_gui.core.utility import apply_colour_to_surface
 
 
 class RoundedRectangleShape(DrawableShape):
@@ -265,14 +266,15 @@ class RoundedRectangleShape(DrawableShape):
                                                     corner_radius=self.shadow_width + 2)
         else:
             quick_surf = pygame.Surface(self.containing_rect.size, flags=pygame.SRCALPHA, depth=32)
-            # quick_surf.fill('#FFFFFF00')
+            quick_surf.fill(pygame.Color('#00000000'))
         if isinstance(self.theming['normal_bg'], ColourGradient):
             grad_surf = pygame.Surface(self.click_area_shape.size, flags=pygame.SRCALPHA, depth=32)
             grad_surf.fill(pygame.Color('#FFFFFFFF'))
             self.theming['normal_bg'].apply_gradient_to_surface(grad_surf)
             quick_surf.blit(grad_surf, pygame.Rect((self.shadow_width,
                                                     self.shadow_width),
-                                                   self.click_area_shape.size))
+                                                   self.click_area_shape.size),
+                            special_flags=pygame.BLEND_PREMULTIPLIED)
         else:
             quick_surf.fill(self.theming['normal_bg'], pygame.Rect((self.shadow_width,
                                                                     self.shadow_width),
@@ -352,9 +354,10 @@ class RoundedRectangleShape(DrawableShape):
                 if isinstance(border_col, ColourGradient):
                     border_col.apply_gradient_to_surface(shape_surface)
                 else:
-                    self.apply_colour_to_surface(border_col, shape_surface)
+                    apply_colour_to_surface(border_col, shape_surface)
 
-                bab_surface.blit(shape_surface, self.border_rect)
+                bab_surface.blit(shape_surface, self.border_rect,
+                                 special_flags=pygame.BLEND_PREMULTIPLIED)
 
             shape_surface = self.clear_and_create_shape_surface(bab_surface,
                                                                 self.background_rect,
@@ -368,13 +371,15 @@ class RoundedRectangleShape(DrawableShape):
                 if isinstance(bg_col, ColourGradient):
                     bg_col.apply_gradient_to_surface(shape_surface)
                 else:
-                    self.apply_colour_to_surface(bg_col, shape_surface)
+                    apply_colour_to_surface(bg_col, shape_surface)
 
-            bab_surface.blit(shape_surface, self.background_rect)
+            bab_surface.blit(shape_surface, self.background_rect,
+                             special_flags=pygame.BLEND_PREMULTIPLIED)
 
             # apply AA to background
             bab_surface = pygame.transform.smoothscale(bab_surface, self.containing_rect.size)
-            self.states[state_str].surface.blit(bab_surface, (0, 0))
+            self.states[state_str].surface.blit(bab_surface, (0, 0),
+                                                special_flags=pygame.BLEND_PREMULTIPLIED)
 
             if self.states[state_str].cached_background_id is not None:
                 cached_id = self.states[state_str].cached_background_id
@@ -415,11 +420,11 @@ class RoundedRectangleShape(DrawableShape):
         if isinstance(bg_col, ColourGradient):
             bg_col.apply_gradient_to_surface(shape_surface, unfilled_bar_rect)
         else:
-            self.apply_colour_to_surface(bg_col, shape_surface, unfilled_bar_rect)
+            apply_colour_to_surface(bg_col, shape_surface, unfilled_bar_rect)
         if isinstance(self.theming['filled_bar'], ColourGradient):
             self.theming['filled_bar'].apply_gradient_to_surface(shape_surface, bar_rect)
         else:
-            self.apply_colour_to_surface(self.theming['filled_bar'], shape_surface, bar_rect)
+            apply_colour_to_surface(self.theming['filled_bar'], shape_surface, bar_rect)
 
     def clear_and_create_shape_surface(self,
                                        surface: pygame.Surface,
@@ -455,7 +460,7 @@ class RoundedRectangleShape(DrawableShape):
         if self.temp_additive_shape is None:
             large_shape_surface = pygame.Surface((rect.width, rect.height),
                                                  flags=pygame.SRCALPHA, depth=32)
-            large_shape_surface.fill(pygame.Color('#FFFFFF00'))  # was:
+            large_shape_surface.fill(pygame.Color('#00000000'))  # was:
             RoundedRectangleShape.draw_colourless_rounded_rectangle(large_corner_radius,
                                                                     large_shape_surface)
             self.temp_additive_shape = large_shape_surface.copy()
@@ -521,7 +526,7 @@ class RoundedRectangleShape(DrawableShape):
     @staticmethod
     def draw_colourless_rounded_rectangle(large_corner_radius: int,
                                           large_shape_surface: pygame.Surface,
-                                          clear_colour_string: str = '#FFFFFF00',
+                                          clear_colour_string: str = '#00000000',
                                           corner_offset: int = 0):
         """
         Draw a rounded rectangle shape in pure white so it is ready to be multiplied by a colour

--- a/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
@@ -542,32 +542,39 @@ class RoundedRectangleShape(DrawableShape):
         :param corner_offset: Offsets the corners, used to help avoid overlaps that look bad.
 
         """
-        pygame.draw.circle(large_shape_surface, pygame.Color('#FFFFFFFF'),
-                           (large_corner_radius + corner_offset,
-                            large_corner_radius + corner_offset), large_corner_radius)
-        if corner_offset > 0:
-            large_shape_surface.fill(pygame.Color(clear_colour_string),
-                                     pygame.Rect(0,
-                                                 int(large_shape_surface.get_height() / 2),
-                                                 large_shape_surface.get_width(),
-                                                 int(large_shape_surface.get_height() / 2)))
-            large_shape_surface.fill(pygame.Color(clear_colour_string),
-                                     pygame.Rect(int(large_shape_surface.get_width() / 2),
-                                                 0,
-                                                 int(large_shape_surface.get_width() / 2),
-                                                 large_shape_surface.get_height()))
+        if pygame.version.vernum[0] >= 2:
+            pygame.draw.rect(large_shape_surface, pygame.Color('#FFFFFFFF'),
+                             pygame.Rect((corner_offset, corner_offset),
+                                         (large_shape_surface.get_width() - corner_offset,
+                                          large_shape_surface.get_height() - corner_offset)),
+                             border_radius=large_corner_radius)
+        else:
+            pygame.draw.circle(large_shape_surface, pygame.Color('#FFFFFFFF'),
+                               (large_corner_radius + corner_offset,
+                                large_corner_radius + corner_offset), large_corner_radius)
+            if corner_offset > 0:
+                large_shape_surface.fill(pygame.Color(clear_colour_string),
+                                         pygame.Rect(0,
+                                                     int(large_shape_surface.get_height() / 2),
+                                                     large_shape_surface.get_width(),
+                                                     int(large_shape_surface.get_height() / 2)))
+                large_shape_surface.fill(pygame.Color(clear_colour_string),
+                                         pygame.Rect(int(large_shape_surface.get_width() / 2),
+                                                     0,
+                                                     int(large_shape_surface.get_width() / 2),
+                                                     large_shape_surface.get_height()))
 
-        x_flip = pygame.transform.flip(large_shape_surface, True, False)
-        large_shape_surface.blit(x_flip, (0, 0))
-        y_flip = pygame.transform.flip(large_shape_surface, False, True)
-        large_shape_surface.blit(y_flip, (0, 0))
-        large_shape_surface.fill(pygame.Color("#FFFFFFFF"),
-                                 pygame.Rect((large_corner_radius, 0),
-                                             (large_shape_surface.get_width() -
-                                              (2 * large_corner_radius),
-                                              large_shape_surface.get_height())))
-        large_shape_surface.fill(pygame.Color("#FFFFFFFF"),
-                                 pygame.Rect((0, large_corner_radius),
-                                             (large_shape_surface.get_width(),
-                                              large_shape_surface.get_height() -
-                                              (2 * large_corner_radius))))
+            x_flip = pygame.transform.flip(large_shape_surface, True, False)
+            large_shape_surface.blit(x_flip, (0, 0))
+            y_flip = pygame.transform.flip(large_shape_surface, False, True)
+            large_shape_surface.blit(y_flip, (0, 0))
+            large_shape_surface.fill(pygame.Color("#FFFFFFFF"),
+                                     pygame.Rect((large_corner_radius, 0),
+                                                 (large_shape_surface.get_width() -
+                                                  (2 * large_corner_radius),
+                                                  large_shape_surface.get_height())))
+            large_shape_surface.fill(pygame.Color("#FFFFFFFF"),
+                                     pygame.Rect((0, large_corner_radius),
+                                                 (large_shape_surface.get_width(),
+                                                  large_shape_surface.get_height() -
+                                                  (2 * large_corner_radius))))

--- a/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
@@ -463,7 +463,7 @@ class RoundedRectangleShape(DrawableShape):
             large_shape_surface.fill(pygame.Color(clear_colour))  # was:
             RoundedRectangleShape.draw_colourless_rounded_rectangle(large_corner_radius,
                                                                     large_shape_surface,
-                                                                    clear_colour_string=clear_colour)
+                                                                    clear_colour)
             self.temp_additive_shape = large_shape_surface.copy()
         else:
             large_shape_surface = pygame.transform.scale(self.temp_additive_shape,

--- a/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
+++ b/pygame_gui/core/drawable_shapes/rounded_rect_drawable_shape.py
@@ -8,7 +8,7 @@ from pygame.math import Vector2
 from pygame_gui.core.interfaces import IUIManagerInterface
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape
-from pygame_gui.core.utility import apply_colour_to_surface
+from pygame_gui.core.utility import apply_colour_to_surface, basic_blit, USE_PREMULTIPLIED_ALPHA
 
 
 class RoundedRectangleShape(DrawableShape):
@@ -271,10 +271,11 @@ class RoundedRectangleShape(DrawableShape):
             grad_surf = pygame.Surface(self.click_area_shape.size, flags=pygame.SRCALPHA, depth=32)
             grad_surf.fill(pygame.Color('#FFFFFFFF'))
             self.theming['normal_bg'].apply_gradient_to_surface(grad_surf)
-            quick_surf.blit(grad_surf, pygame.Rect((self.shadow_width,
-                                                    self.shadow_width),
-                                                   self.click_area_shape.size),
-                            special_flags=pygame.BLEND_PREMULTIPLIED)
+
+            basic_blit(quick_surf, grad_surf,
+                       pygame.Rect((self.shadow_width,
+                                    self.shadow_width),
+                                   self.click_area_shape.size))
         else:
             quick_surf.fill(self.theming['normal_bg'], pygame.Rect((self.shadow_width,
                                                                     self.shadow_width),
@@ -356,8 +357,7 @@ class RoundedRectangleShape(DrawableShape):
                 else:
                     apply_colour_to_surface(border_col, shape_surface)
 
-                bab_surface.blit(shape_surface, self.border_rect,
-                                 special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(bab_surface, shape_surface, self.border_rect)
 
             shape_surface = self.clear_and_create_shape_surface(bab_surface,
                                                                 self.background_rect,
@@ -373,13 +373,12 @@ class RoundedRectangleShape(DrawableShape):
                 else:
                     apply_colour_to_surface(bg_col, shape_surface)
 
-            bab_surface.blit(shape_surface, self.background_rect,
-                             special_flags=pygame.BLEND_PREMULTIPLIED)
+            basic_blit(bab_surface, shape_surface, self.background_rect)
 
             # apply AA to background
             bab_surface = pygame.transform.smoothscale(bab_surface, self.containing_rect.size)
-            self.states[state_str].surface.blit(bab_surface, (0, 0),
-                                                special_flags=pygame.BLEND_PREMULTIPLIED)
+
+            basic_blit(self.states[state_str].surface, bab_surface, (0, 0))
 
             if self.states[state_str].cached_background_id is not None:
                 cached_id = self.states[state_str].cached_background_id
@@ -460,9 +459,11 @@ class RoundedRectangleShape(DrawableShape):
         if self.temp_additive_shape is None:
             large_shape_surface = pygame.Surface((rect.width, rect.height),
                                                  flags=pygame.SRCALPHA, depth=32)
-            large_shape_surface.fill(pygame.Color('#00000000'))  # was:
+            clear_colour = '#00000000' if USE_PREMULTIPLIED_ALPHA else '#FFFFFF00'
+            large_shape_surface.fill(pygame.Color(clear_colour))  # was:
             RoundedRectangleShape.draw_colourless_rounded_rectangle(large_corner_radius,
-                                                                    large_shape_surface)
+                                                                    large_shape_surface,
+                                                                    clear_colour_string=clear_colour)
             self.temp_additive_shape = large_shape_surface.copy()
         else:
             large_shape_surface = pygame.transform.scale(self.temp_additive_shape,

--- a/pygame_gui/core/interfaces/container_interface.py
+++ b/pygame_gui/core/interfaces/container_interface.py
@@ -109,7 +109,7 @@ class IUIContainerInterface(metaclass=ABCMeta):
     def get_top_layer(self) -> int:
         """
         Assuming we have correctly calculated the 'thickness' of this container, this method will
-        return the 'highest' layer in the LayeredUpdates UI Group.
+        return the 'highest' layer in the LayeredDirty UI Group.
 
         :return: An integer representing the current highest layer being used by this container.
         """

--- a/pygame_gui/core/interfaces/manager_interface.py
+++ b/pygame_gui/core/interfaces/manager_interface.py
@@ -44,7 +44,7 @@ class IUIManagerInterface(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def get_sprite_group(self) -> pygame.sprite.LayeredUpdates:
+    def get_sprite_group(self) -> pygame.sprite.LayeredDirty:
         """
         Gets the sprite group used by the entire UI to keep it in the correct order for drawing and
         processing input.
@@ -111,6 +111,12 @@ class IUIManagerInterface(metaclass=ABCMeta):
     def get_mouse_position(self) -> Tuple[int, int]:
         """
         Get the position of the mouse in the UI.
+        """
+
+    @abstractmethod
+    def calculate_scaled_mouse_position(self, position: Tuple[int, int]) -> Tuple[int, int]:
+        """
+        Scaling an input mouse position by a scale factor.
         """
 
     @abstractmethod

--- a/pygame_gui/core/surface_cache.py
+++ b/pygame_gui/core/surface_cache.py
@@ -4,6 +4,7 @@ from typing import List, Union, Tuple
 
 import pygame
 
+from pygame_gui.core.utility import basic_blit
 from pygame_gui.core.colour_gradient import ColourGradient
 
 
@@ -154,8 +155,7 @@ class SurfaceCache:
                 found_rectangle_to_split = free_rectangle
                 found_rectangle_cache = pygame.Rect(free_rectangle.topleft,
                                                     surface_size)
-                current_surface.blit(new_item[0], free_rectangle.topleft,
-                                     special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(current_surface, new_item[0], free_rectangle.topleft)
                 self.cache_long_term_lookup[string_id] = {
                     'surface': current_surface.subsurface(found_rectangle_cache),
                     'current_uses': new_item[1],

--- a/pygame_gui/core/surface_cache.py
+++ b/pygame_gui/core/surface_cache.py
@@ -154,7 +154,8 @@ class SurfaceCache:
                 found_rectangle_to_split = free_rectangle
                 found_rectangle_cache = pygame.Rect(free_rectangle.topleft,
                                                     surface_size)
-                current_surface.blit(new_item[0], free_rectangle.topleft)
+                current_surface.blit(new_item[0], free_rectangle.topleft,
+                                     special_flags=pygame.BLEND_PREMULTIPLIED)
                 self.cache_long_term_lookup[string_id] = {
                     'surface': current_surface.subsurface(found_rectangle_cache),
                     'current_uses': new_item[1],

--- a/pygame_gui/core/ui_appearance_theme.py
+++ b/pygame_gui/core/ui_appearance_theme.py
@@ -13,7 +13,7 @@ import pygame
 from pygame_gui.core.interfaces.font_dictionary_interface import IUIFontDictionaryInterface
 from pygame_gui.core.interfaces.colour_gradient_interface import IColourGradientInterface
 from pygame_gui.core.interfaces.appearance_theme_interface import IUIAppearanceThemeInterface
-from pygame_gui.core.utility import create_resource_path, PackageResource
+from pygame_gui.core.utility import create_resource_path, PackageResource, premul_col
 from pygame_gui.core.utility import ImageResource, SurfaceResource
 from pygame_gui.core.ui_font_dictionary import UIFontDictionary
 from pygame_gui.core.ui_shadow import ShadowGenerator
@@ -76,28 +76,7 @@ class UIAppearanceTheme(IUIAppearanceThemeInterface):
 
         # the base colours are the default colours all UI elements use if they
         # don't have a more specific colour defined for their element
-        self.base_colours = {'normal_bg': pygame.Color('#25292e'),
-                             'hovered_bg': pygame.Color('#35393e'),
-                             'disabled_bg': pygame.Color('#25292e'),
-                             'selected_bg': pygame.Color('#193754'),
-                             'active_bg': pygame.Color('#193754'),
-                             'dark_bg': pygame.Color('#15191e'),
-                             'normal_text': pygame.Color('#c5cbd8'),
-                             'hovered_text': pygame.Color('#FFFFFF'),
-                             'selected_text': pygame.Color('#FFFFFF'),
-                             'active_text': pygame.Color('#FFFFFF'),
-                             'disabled_text': pygame.Color('#6d736f'),
-                             'normal_border': pygame.Color('#DDDDDD'),
-                             'hovered_border': pygame.Color('#EDEDED'),
-                             'disabled_border': pygame.Color('#909090'),
-                             'selected_border': pygame.Color('#294764'),
-                             'active_border': pygame.Color('#294764'),
-                             'link_text': pygame.Color('#c5cbFF'),
-                             'link_hover': pygame.Color('#a5abDF'),
-                             'link_selected': pygame.Color('#DFabDF'),
-                             'text_shadow': pygame.Color('#777777'),
-                             'filled_bar': pygame.Color("#f4251b"),
-                             'unfilled_bar': pygame.Color("#CCCCCC")}
+        self.base_colours = {}
 
         # colours for specific elements stored by element id then colour id
         self.ui_element_colours = {}
@@ -962,8 +941,8 @@ class UIAppearanceTheme(IUIAppearanceThemeInterface):
                 if len(string_data_list) == 3:
                     # two colour gradient
                     try:
-                        colour_1 = pygame.Color(string_data_list[0])
-                        colour_2 = pygame.Color(string_data_list[1])
+                        colour_1 = premul_col(pygame.Color(string_data_list[0]))
+                        colour_2 = premul_col(pygame.Color(string_data_list[1]))
                         loaded_colour_or_gradient = ColourGradient(gradient_direction,
                                                                    colour_1,
                                                                    colour_2)
@@ -973,9 +952,9 @@ class UIAppearanceTheme(IUIAppearanceThemeInterface):
                 elif len(string_data_list) == 4:
                     # three colour gradient
                     try:
-                        colour_1 = pygame.Color(string_data_list[0])
-                        colour_2 = pygame.Color(string_data_list[1])
-                        colour_3 = pygame.Color(string_data_list[2])
+                        colour_1 = premul_col(pygame.Color(string_data_list[0]))
+                        colour_2 = premul_col(pygame.Color(string_data_list[1]))
+                        colour_3 = premul_col(pygame.Color(string_data_list[2]))
                         loaded_colour_or_gradient = ColourGradient(gradient_direction,
                                                                    colour_1,
                                                                    colour_2,
@@ -989,7 +968,7 @@ class UIAppearanceTheme(IUIAppearanceThemeInterface):
         else:
             # expecting a regular hex colour in string data
             try:
-                loaded_colour_or_gradient = pygame.Color(string_data)
+                loaded_colour_or_gradient = premul_col(pygame.Color(string_data))
             except ValueError:
                 warnings.warn("Colour hex code: " +
                               string_data +

--- a/pygame_gui/core/ui_appearance_theme.py
+++ b/pygame_gui/core/ui_appearance_theme.py
@@ -46,7 +46,7 @@ except ImportError:
             USE_FILE_PATH = True
         else:
             USE_STRINGIFIED_DATA = True
-            from pygame_gui.core._string_data import default_theme
+            from pygame_gui.core._string_data import default_theme  # pylint: disable=ungrouped-imports
     else:
         USE_IMPORT_LIB_RESOURCE = True
 

--- a/pygame_gui/core/ui_container.py
+++ b/pygame_gui/core/ui_container.py
@@ -208,7 +208,7 @@ class UIContainer(UIElement, IUIContainerInterface, IContainerLikeInterface):
     def get_top_layer(self) -> int:
         """
         Assuming we have correctly calculated the 'thickness' of this container, this method will
-        return the 'highest' layer in the LayeredUpdates UI Group.
+        return the 'highest' layer in the LayeredDirty UI Group.
 
         :return: An integer representing the current highest layer being used by this container.
         """

--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -5,9 +5,10 @@ import pygame
 
 from pygame_gui.core.interfaces import IUIElementInterface
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
+from pygame_gui.core.utility import render_white_text_alpha_black_bg
 
 
-class UIElement(pygame.sprite.Sprite, IUIElementInterface):
+class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
     """
     A base class for UI elements. You shouldn't create UI Element objects, instead all UI Element
     classes should derive from this class. Inherits from pygame.sprite.Sprite.
@@ -51,6 +52,11 @@ class UIElement(pygame.sprite.Sprite, IUIElementInterface):
                             'bottom': 'top'}
         self.drawable_shape = None  # type: Union['DrawableShape', None]
         self.image = None
+
+        self.dirty = 2
+        self.visible = 1
+        self.blendmode = pygame.BLEND_PREMULTIPLIED
+        self.source_rect = None
 
         self.relative_bottom_margin = None
         self.relative_right_margin = None
@@ -563,8 +569,8 @@ class UIElement(pygame.sprite.Sprite, IUIElementInterface):
         """
         if activate_mode:
             default_font = self.ui_manager.get_theme().get_font_dictionary().get_default_font()
-            layer_text_render = default_font.render("UI Layer: " + str(self._layer),
-                                                    True, pygame.Color('#FFFFFFFF'))
+            layer_text_render = render_white_text_alpha_black_bg(default_font,
+                                                                 "UI Layer: " + str(self._layer))
 
             if self.image is not None:
                 self.pre_debug_image = self.image.copy()
@@ -584,9 +590,11 @@ class UIElement(pygame.sprite.Sprite, IUIElementInterface):
                     new_surface = pygame.Surface((surf_width, surf_height),
                                                  flags=pygame.SRCALPHA,
                                                  depth=32)
-                    new_surface.blit(self.image, (0, 0))
+                    new_surface.blit(self.image, (0, 0),
+                                     special_flags=pygame.BLEND_PREMULTIPLIED)
                     self.set_image(new_surface)
-                self.image.blit(layer_text_render, (0, 0))
+                self.image.blit(layer_text_render, (0, 0),
+                                special_flags=pygame.BLEND_PREMULTIPLIED)
             else:
                 self.set_image(layer_text_render)
             self._visual_debug_mode = True
@@ -628,7 +636,8 @@ class UIElement(pygame.sprite.Sprite, IUIElementInterface):
             self._image_clip = rect
             if self.image is not None:
                 self.image.fill(pygame.Color('#00000000'))
-                self.image.blit(self._pre_clipped_image, self._image_clip, self._image_clip)
+                self.image.blit(self._pre_clipped_image, self._image_clip, self._image_clip,
+                                special_flags=pygame.BLEND_PREMULTIPLIED)
         else:
             self._image_clip = None
 
@@ -661,7 +670,8 @@ class UIElement(pygame.sprite.Sprite, IUIElementInterface):
                 self.image.fill(pygame.Color('#00000000'))
                 self.image.blit(self._pre_clipped_image,
                                 self.get_image_clipping_rect(),
-                                self.get_image_clipping_rect())
+                                self.get_image_clipping_rect(),
+                                special_flags=pygame.BLEND_PREMULTIPLIED)
         else:
             self.image = new_image.copy() if new_image is not None else None
             self._pre_clipped_image = None

--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -5,7 +5,8 @@ import pygame
 
 from pygame_gui.core.interfaces import IUIElementInterface
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
-from pygame_gui.core.utility import render_white_text_alpha_black_bg
+from pygame_gui.core.utility import render_white_text_alpha_black_bg, USE_PREMULTIPLIED_ALPHA
+from pygame_gui.core.utility import basic_blit
 
 
 class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
@@ -55,7 +56,7 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
 
         self.dirty = 2
         self.visible = 1
-        self.blendmode = pygame.BLEND_PREMULTIPLIED
+        self.blendmode = pygame.BLEND_PREMULTIPLIED if USE_PREMULTIPLIED_ALPHA else 0
         self.source_rect = None
 
         self.relative_bottom_margin = None
@@ -90,7 +91,7 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         if isinstance(container, IContainerLikeInterface):
             self.ui_container = container.get_container()
 
-        if self.ui_container is not None and self.ui_container is not self:
+        if not (self.ui_container is None or self.ui_container is self):
             self.ui_container.add_element(self)
 
         self._update_absolute_rect_position_from_anchors()
@@ -590,11 +591,9 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
                     new_surface = pygame.Surface((surf_width, surf_height),
                                                  flags=pygame.SRCALPHA,
                                                  depth=32)
-                    new_surface.blit(self.image, (0, 0),
-                                     special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(new_surface, self.image, (0, 0))
                     self.set_image(new_surface)
-                self.image.blit(layer_text_render, (0, 0),
-                                special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.image, layer_text_render, (0, 0))
             else:
                 self.set_image(layer_text_render)
             self._visual_debug_mode = True
@@ -636,8 +635,7 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
             self._image_clip = rect
             if self.image is not None:
                 self.image.fill(pygame.Color('#00000000'))
-                self.image.blit(self._pre_clipped_image, self._image_clip, self._image_clip,
-                                special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.image, self._pre_clipped_image, self._image_clip, self._image_clip)
         else:
             self._image_clip = None
 
@@ -668,10 +666,10 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
                                             flags=pygame.SRCALPHA,
                                             depth=32)
                 self.image.fill(pygame.Color('#00000000'))
-                self.image.blit(self._pre_clipped_image,
-                                self.get_image_clipping_rect(),
-                                self.get_image_clipping_rect(),
-                                special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(self.image,
+                           self._pre_clipped_image,
+                           self.get_image_clipping_rect(),
+                           self.get_image_clipping_rect())
         else:
             self.image = new_image.copy() if new_image is not None else None
             self._pre_clipped_image = None

--- a/pygame_gui/core/ui_shadow.py
+++ b/pygame_gui/core/ui_shadow.py
@@ -184,6 +184,7 @@ class ShadowGenerator:
         if shadow_id in self.short_term_rect_cache:
             return self.short_term_rect_cache[shadow_id]
         final_surface = pygame.Surface((width, height), flags=pygame.SRCALPHA, depth=32)
+        final_surface.fill(pygame.Color('#00000000'))
 
         corner_index_id = str(shadow_width_param) + 'x' + str(corner_radius_param)
         if corner_index_id in self.preloaded_shadow_corners:

--- a/pygame_gui/core/utility.py
+++ b/pygame_gui/core/utility.py
@@ -9,6 +9,7 @@ import contextlib
 import os
 import sys
 import io
+import re
 import base64
 
 from pathlib import Path
@@ -19,8 +20,13 @@ from queue import Queue
 
 import pygame
 
-# Only use pre-multiplied alpha if we are using SDL2 where it is decently fast.
-USE_PREMULTIPLIED_ALPHA = pygame.version.vernum[0] >= 2
+# Only use pre-multiplied alpha if we are using SDL2 past dev 10 where it is decently fast.
+if 'dev' in pygame.ver.split('.')[-1]:
+    PYGAME_DEV_NUM = int(re.findall(r'\d+', pygame.ver.split('.')[-1])[0])
+else:
+    PYGAME_DEV_NUM = 10
+
+USE_PREMULTIPLIED_ALPHA = pygame.version.vernum[0] >= 2 and PYGAME_DEV_NUM >= 10
 
 USE_IMPORT_LIB_RESOURCE = False
 USE_FILE_PATH = False
@@ -289,6 +295,16 @@ def basic_blit(destination: pygame.Surface,
                source: pygame.Surface,
                pos: Union[Tuple[int, int], pygame.Rect],
                area: Union[pygame.Rect, None] = None):
+    """
+    The basic blitting function to use. WE need to wrap this so we can support pre-multiplied alpha
+    on post 2.0.0.dev10 versions of pygame and regular blitting on earlier versions.
+
+    :param destination: Destination surface to blit on to.
+    :param source: Source surface to blit from.
+    :param pos: The position of our blit.
+    :param area: The area of the source to blit from.
+
+    """
     if USE_PREMULTIPLIED_ALPHA:
         destination.blit(source, pos, area, special_flags=pygame.BLEND_PREMULTIPLIED)
     else:

--- a/pygame_gui/data/default_theme.json
+++ b/pygame_gui/data/default_theme.json
@@ -23,7 +23,6 @@
             "link_hover": "#84bfed",
             "link_selected": "#84bfed",
             "text_shadow": "#777777",
-            "border": "#5e6060",
             "filled_bar": "#f4251b",
             "unfilled_bar": "#CCCCCC"
         }

--- a/pygame_gui/elements/text/styled_chunk.py
+++ b/pygame_gui/elements/text/styled_chunk.py
@@ -79,13 +79,17 @@ class StyledChunk:
                     self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
                     apply_colour_to_surface(self.colour, self.rendered_chunk)
                 else:
-                    self.rendered_chunk = self.font.render(self.chunk, True,
-                                                           self.colour, self.bg_colour)
+                    self.rendered_chunk = self.font.render(self.chunk,
+                                                           True,
+                                                           self.colour,
+                                                           self.bg_colour).convert_alpha()
             else:
                 self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
                 self.colour.apply_gradient_to_surface(self.rendered_chunk)
         else:
-            self.rendered_chunk = pygame.Surface((0, 0))
+            self.rendered_chunk = pygame.Surface((0, 0),
+                                                 flags=pygame.SRCALPHA,
+                                                 depth=32)
         metrics = self.font.metrics(self.chunk)
         self.ascent = self.font.get_ascent()
         self.width = self.font.size(self.chunk)[0]
@@ -126,10 +130,14 @@ class StyledChunk:
                     self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
                     apply_colour_to_surface(self.colour, self.rendered_chunk)
                 else:
-                    self.rendered_chunk = self.font.render(self.chunk, True,
-                                                           self.colour, self.bg_colour)
+                    self.rendered_chunk = self.font.render(self.chunk,
+                                                           True,
+                                                           self.colour,
+                                                           self.bg_colour).convert_alpha()
         else:
-            self.rendered_chunk = pygame.Surface((0, 0))
+            self.rendered_chunk = pygame.Surface((0, 0),
+                                                 flags=pygame.SRCALPHA,
+                                                 depth=32)
 
         self.font.set_underline(False)
 

--- a/pygame_gui/elements/text/styled_chunk.py
+++ b/pygame_gui/elements/text/styled_chunk.py
@@ -3,6 +3,7 @@ from typing import Tuple, Union
 import pygame
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.ui_font_dictionary import UIFontDictionary
+from pygame_gui.core.utility import render_white_text_alpha_black_bg, apply_colour_to_surface
 
 from pygame_gui.elements.text.html_parser import CharStyle
 
@@ -75,12 +76,13 @@ class StyledChunk:
         if len(self.chunk) > 0:
             if not isinstance(self.colour, ColourGradient):
                 if isinstance(self.bg_colour, ColourGradient) or self.bg_colour.a != 255:
-                    self.rendered_chunk = self.font.render(self.chunk, True, self.colour)
+                    self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
+                    apply_colour_to_surface(self.colour, self.rendered_chunk)
                 else:
                     self.rendered_chunk = self.font.render(self.chunk, True,
                                                            self.colour, self.bg_colour)
             else:
-                self.rendered_chunk = self.font.render(self.chunk, True, pygame.Color('#FFFFFFFF'))
+                self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
                 self.colour.apply_gradient_to_surface(self.rendered_chunk)
         else:
             self.rendered_chunk = pygame.Surface((0, 0))
@@ -117,11 +119,12 @@ class StyledChunk:
 
         if len(self.chunk) > 0:
             if isinstance(self.colour, ColourGradient):
-                self.rendered_chunk = self.font.render(self.chunk, True, pygame.Color('#FFFFFFFF'))
+                self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
                 self.colour.apply_gradient_to_surface(self.rendered_chunk)
             else:
                 if isinstance(self.bg_colour, ColourGradient) or self.bg_colour.a != 255:
-                    self.rendered_chunk = self.font.render(self.chunk, True, self.colour)
+                    self.rendered_chunk = render_white_text_alpha_black_bg(self.font, self.chunk)
+                    apply_colour_to_surface(self.colour, self.rendered_chunk)
                 else:
                     self.rendered_chunk = self.font.render(self.chunk, True,
                                                            self.colour, self.bg_colour)

--- a/pygame_gui/elements/text/text_block.py
+++ b/pygame_gui/elements/text/text_block.py
@@ -338,6 +338,7 @@ class TextBlock:
         if self.height != -1 and self.width != -1:
             self.block_sprite = pygame.Surface((self.width, self.height),
                                                pygame.SRCALPHA, depth=32)
+            self.block_sprite.fill(pygame.Color('#00000000'))
         position = [0, 0]
         line_height_acc = 0
         max_line_length = 0
@@ -364,7 +365,8 @@ class TextBlock:
                 if self.block_sprite is not None:
                     # need to adjust y start pos based on ascents
                     new_chunk.rect.y += (line['line_ascent'] - new_chunk.ascent)
-                    self.block_sprite.blit(new_chunk.rendered_chunk, new_chunk.rect)
+                    self.block_sprite.blit(new_chunk.rendered_chunk, new_chunk.rect,
+                                           special_flags=pygame.BLEND_PREMULTIPLIED)
 
             text_line = TextBlock.TextLine()
             text_line.chunks = line_chunks
@@ -381,12 +383,14 @@ class TextBlock:
             self.height = line_height_acc if self.height == -1 else self.height
             self.block_sprite = pygame.Surface((self.width, self.height),
                                                pygame.SRCALPHA, depth=32)
+            self.block_sprite.fill(pygame.Color('#00000000'))
 
             for line in self.lines:
                 for chunk in line.chunks:
                     # need to adjust y start pos based on ascents
                     chunk.rect.y += line.max_line_ascent - chunk.ascent
-                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect)
+                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect,
+                                           special_flags=pygame.BLEND_PREMULTIPLIED)
 
         self.final_dimensions = (self.width, self.height)
 
@@ -400,6 +404,7 @@ class TextBlock:
         final_alpha = text_effect.get_final_alpha() if text_effect else 255
         self.block_sprite = pygame.Surface((self.width, self.height),
                                            flags=pygame.SRCALPHA, depth=32)
+        self.block_sprite.fill(pygame.Color('#00000000'))
 
         if isinstance(self.bg_colour, ColourGradient):
             self.block_sprite.fill(pygame.Color("#FFFFFFFF"))
@@ -410,7 +415,8 @@ class TextBlock:
         for text_line in self.lines:
             for chunk in text_line.chunks:
                 if self.block_sprite is not None:
-                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect)
+                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect,
+                                           special_flags=pygame.BLEND_PREMULTIPLIED)
         self.block_sprite.set_alpha(final_alpha)
 
     def add_chunks_to_hover_group(self, hover_group: List[StyledChunk]):

--- a/pygame_gui/elements/text/text_block.py
+++ b/pygame_gui/elements/text/text_block.py
@@ -5,6 +5,7 @@ import pygame
 
 from pygame_gui.core.colour_gradient import ColourGradient
 from pygame_gui.core.ui_font_dictionary import UIFontDictionary
+from pygame_gui.core.utility import basic_blit
 
 from pygame_gui.elements.text.text_effects import TextBoxEffect
 from pygame_gui.elements.text.styled_chunk import StyledChunk
@@ -346,27 +347,27 @@ class TextBlock:
             line_chunks = []
             max_line_char_height = 0
             for chunk in line['chunks']:
-                new_chunk = StyledChunk(chunk['style'].font_size,
-                                        chunk['style'].font_name,
-                                        chunk['text'],
-                                        chunk['style'].style,
-                                        chunk['style'].colour,
-                                        chunk['style'].bg_colour,
-                                        chunk['style'].is_link,
-                                        chunk['style'].link_href,
-                                        self.link_style,
-                                        (position[0], position[1]),
-                                        self.font_dict)
-                position[0] += new_chunk.advance
-                if new_chunk.height > max_line_char_height:
-                    max_line_char_height = new_chunk.height
-                line_chunks.append(new_chunk)
+                if len(chunk['text']) > 0:
+                    new_chunk = StyledChunk(chunk['style'].font_size,
+                                            chunk['style'].font_name,
+                                            chunk['text'],
+                                            chunk['style'].style,
+                                            chunk['style'].colour,
+                                            chunk['style'].bg_colour,
+                                            chunk['style'].is_link,
+                                            chunk['style'].link_href,
+                                            self.link_style,
+                                            (position[0], position[1]),
+                                            self.font_dict)
+                    position[0] += new_chunk.advance
+                    if new_chunk.height > max_line_char_height:
+                        max_line_char_height = new_chunk.height
+                    line_chunks.append(new_chunk)
 
-                if self.block_sprite is not None:
-                    # need to adjust y start pos based on ascents
-                    new_chunk.rect.y += (line['line_ascent'] - new_chunk.ascent)
-                    self.block_sprite.blit(new_chunk.rendered_chunk, new_chunk.rect,
-                                           special_flags=pygame.BLEND_PREMULTIPLIED)
+                    if self.block_sprite is not None:
+                        # need to adjust y start pos based on ascents
+                        new_chunk.rect.y += (line['line_ascent'] - new_chunk.ascent)
+                        basic_blit(self.block_sprite, new_chunk.rendered_chunk, new_chunk.rect)
 
             text_line = TextBlock.TextLine()
             text_line.chunks = line_chunks
@@ -389,8 +390,7 @@ class TextBlock:
                 for chunk in line.chunks:
                     # need to adjust y start pos based on ascents
                     chunk.rect.y += line.max_line_ascent - chunk.ascent
-                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect,
-                                           special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(self.block_sprite, chunk.rendered_chunk, chunk.rect)
 
         self.final_dimensions = (self.width, self.height)
 
@@ -415,8 +415,7 @@ class TextBlock:
         for text_line in self.lines:
             for chunk in text_line.chunks:
                 if self.block_sprite is not None:
-                    self.block_sprite.blit(chunk.rendered_chunk, chunk.rect,
-                                           special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(self.block_sprite, chunk.rendered_chunk, chunk.rect)
         self.block_sprite.set_alpha(final_alpha)
 
     def add_chunks_to_hover_group(self, hover_group: List[StyledChunk]):

--- a/pygame_gui/elements/ui_image.py
+++ b/pygame_gui/elements/ui_image.py
@@ -4,6 +4,7 @@ import pygame
 
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core import UIElement
+from pygame_gui.core.utility import premul_alpha_surface
 
 
 class UIImage(UIElement):
@@ -43,7 +44,9 @@ class UIImage(UIElement):
                                element_id='image')
 
         self.original_image = None
-        image_surface = image_surface.convert_alpha()  # GUI images must support an alpha channel
+        # GUI images must support an alpha channel & must have their alpha channel pre-multiplied
+        # with their colours.
+        image_surface = premul_alpha_surface(image_surface.convert_alpha())
         if (image_surface.get_width() != self.rect.width or
                 image_surface.get_height() != self.rect.height):
             self.original_image = image_surface

--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -5,6 +5,7 @@ import pygame
 
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core import ColourGradient, UIElement
+from pygame_gui.core.utility import render_white_text_alpha_black_bg, apply_colour_to_surface
 
 
 class UILabel(UIElement):
@@ -85,57 +86,63 @@ class UILabel(UIElement):
         if isinstance(self.bg_colour, ColourGradient):
             new_image.fill(pygame.Color('#FFFFFFFF'))
             self.bg_colour.apply_gradient_to_surface(new_image)
+            text_render = render_white_text_alpha_black_bg(self.font, self.text)
             if isinstance(self.text_colour, ColourGradient):
-                text_render = self.font.render(self.text, True, pygame.Color('#FFFFFFFF'))
                 self.text_colour.apply_gradient_to_surface(text_render)
-
             else:
-                text_render = self.font.render(self.text, True, self.text_colour)
+                apply_colour_to_surface(self.text_colour, text_render)
         elif isinstance(self.text_colour, ColourGradient):
             new_image.fill(self.bg_colour)
-            text_render = self.font.render(self.text, True, pygame.Color('#FFFFFFFF'))
+            text_render = render_white_text_alpha_black_bg(self.font, self.text)
             self.text_colour.apply_gradient_to_surface(text_render)
         else:
             new_image.fill(self.bg_colour)
             if self.bg_colour.a != 255 or self.text_shadow:
-                text_render = self.font.render(self.text, True, self.text_colour)
+                text_render = render_white_text_alpha_black_bg(self.font, self.text)
+                apply_colour_to_surface(self.text_colour, text_render)
             else:
                 text_render = self.font.render(self.text, True, self.text_colour, self.bg_colour)
         text_render_rect = text_render.get_rect(centerx=int(self.rect.width / 2),
                                                 centery=int(self.rect.height / 2))
 
         if self.text_shadow:
-            shadow_text_render = self.font.render(self.text, True, self.text_shadow_colour)
+            shadow_text_render = render_white_text_alpha_black_bg(self.font, self.text)
+            apply_colour_to_surface(self.text_shadow_colour, shadow_text_render)
 
             for y_pos in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect((text_render_rect.x + self.text_shadow_offset[0],
                                                 text_render_rect.y + self.text_shadow_offset[1]
                                                 + y_pos),
                                                text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect)
+                new_image.blit(shadow_text_render, shadow_text_rect,
+                               special_flags=pygame.BLEND_PREMULTIPLIED)
 
             for x_pos in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect((text_render_rect.x + self.text_shadow_offset[0]
                                                 + x_pos,
                                                 text_render_rect.y + self.text_shadow_offset[1]),
                                                text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect)
+                new_image.blit(shadow_text_render, shadow_text_rect,
+                               special_flags=pygame.BLEND_PREMULTIPLIED)
 
             for x_and_y in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect(
                     (text_render_rect.x + self.text_shadow_offset[0] + x_and_y,
                      text_render_rect.y + self.text_shadow_offset[1] + x_and_y),
                     text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect)
+                new_image.blit(shadow_text_render, shadow_text_rect,
+                               special_flags=pygame.BLEND_PREMULTIPLIED)
 
             for x_and_y in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect(
                     (text_render_rect.x + self.text_shadow_offset[0] - x_and_y,
                      text_render_rect.y + self.text_shadow_offset[1] + x_and_y),
                     text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect)
+                new_image.blit(shadow_text_render, shadow_text_rect,
+                               special_flags=pygame.BLEND_PREMULTIPLIED)
 
-        new_image.blit(text_render, text_render_rect)
+        new_image.blit(text_render, text_render_rect,
+                       special_flags=pygame.BLEND_PREMULTIPLIED)
 
         self.set_image(new_image)
 

--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -6,6 +6,7 @@ import pygame
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core import ColourGradient, UIElement
 from pygame_gui.core.utility import render_white_text_alpha_black_bg, apply_colour_to_surface
+from pygame_gui.core.utility import basic_blit
 
 
 class UILabel(UIElement):
@@ -102,6 +103,7 @@ class UILabel(UIElement):
                 apply_colour_to_surface(self.text_colour, text_render)
             else:
                 text_render = self.font.render(self.text, True, self.text_colour, self.bg_colour)
+                text_render = text_render.convert_alpha()
         text_render_rect = text_render.get_rect(centerx=int(self.rect.width / 2),
                                                 centery=int(self.rect.height / 2))
 
@@ -114,35 +116,30 @@ class UILabel(UIElement):
                                                 text_render_rect.y + self.text_shadow_offset[1]
                                                 + y_pos),
                                                text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect,
-                               special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(new_image, shadow_text_render, shadow_text_rect)
 
             for x_pos in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect((text_render_rect.x + self.text_shadow_offset[0]
                                                 + x_pos,
                                                 text_render_rect.y + self.text_shadow_offset[1]),
                                                text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect,
-                               special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(new_image, shadow_text_render, shadow_text_rect)
 
             for x_and_y in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect(
                     (text_render_rect.x + self.text_shadow_offset[0] + x_and_y,
                      text_render_rect.y + self.text_shadow_offset[1] + x_and_y),
                     text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect,
-                               special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(new_image, shadow_text_render, shadow_text_rect)
 
             for x_and_y in range(-self.text_shadow_size, self.text_shadow_size + 1):
                 shadow_text_rect = pygame.Rect(
                     (text_render_rect.x + self.text_shadow_offset[0] - x_and_y,
                      text_render_rect.y + self.text_shadow_offset[1] + x_and_y),
                     text_render_rect.size)
-                new_image.blit(shadow_text_render, shadow_text_rect,
-                               special_flags=pygame.BLEND_PREMULTIPLIED)
+                basic_blit(new_image, shadow_text_render, shadow_text_rect)
 
-        new_image.blit(text_render, text_render_rect,
-                       special_flags=pygame.BLEND_PREMULTIPLIED)
+        basic_blit(new_image, text_render, text_render_rect)
 
         self.set_image(new_image)
 

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -249,13 +249,14 @@ class UITextBox(UIElement):
                                      self.text_wrap_rect[3]))
         new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
         new_image.fill(pygame.Color(0, 0, 0, 0))
-        new_image.blit(self.background_surf, (0, 0))
+        new_image.blit(self.background_surf, (0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
         new_image.blit(self.formatted_text_block.block_sprite,
                        (self.padding[0] + self.border_width +
                         self.shadow_width + self.rounded_corner_offset,
                         self.padding[1] + self.border_width +
                         self.shadow_width + self.rounded_corner_offset),
-                       drawable_area)
+                       drawable_area,
+                       special_flags=pygame.BLEND_PREMULTIPLIED)
 
         self.set_image(new_image)
 
@@ -287,7 +288,8 @@ class UITextBox(UIElement):
 
             new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
             new_image.fill(pygame.Color(0, 0, 0, 0))
-            new_image.blit(self.background_surf, (0, 0))
+            new_image.blit(self.background_surf, (0, 0),
+                           special_flags=pygame.BLEND_PREMULTIPLIED)
             new_image.blit(self.formatted_text_block.block_sprite,
                            (self.padding[0] + self.border_width +
                             self.shadow_width +
@@ -295,7 +297,8 @@ class UITextBox(UIElement):
                             self.padding[1] + self.border_width +
                             self.shadow_width +
                             self.rounded_corner_offset),
-                           drawable_area)
+                           drawable_area,
+                           special_flags=pygame.BLEND_PREMULTIPLIED)
             self.set_image(new_image)
 
         mouse_x, mouse_y = self.ui_manager.get_mouse_position()
@@ -420,7 +423,9 @@ class UITextBox(UIElement):
                     new_image = pygame.Surface(self.relative_rect.size,
                                                flags=pygame.SRCALPHA,
                                                depth=32)
-                    new_image.blit(self.image, (0, 0))
+                    new_image.fill(pygame.Color('#00000000'))
+                    new_image.blit(self.image, (0, 0),
+                                   special_flags=pygame.BLEND_PREMULTIPLIED)
                     self.set_image(new_image)
 
                     if self.scroll_bar is not None:
@@ -473,13 +478,15 @@ class UITextBox(UIElement):
                                     (self.text_wrap_rect[2], self.text_wrap_rect[3]))
         new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
         new_image.fill(pygame.Color(0, 0, 0, 0))
-        new_image.blit(self.background_surf, (0, 0))
+        new_image.blit(self.background_surf, (0, 0),
+                       special_flags=pygame.BLEND_PREMULTIPLIED)
         new_image.blit(self.formatted_text_block.block_sprite,
                        (self.padding[0] + self.border_width +
                         self.shadow_width + self.rounded_corner_offset,
                         self.padding[1] + self.border_width +
                         self.shadow_width + self.rounded_corner_offset),
-                       drawable_area)
+                       drawable_area,
+                       special_flags=pygame.BLEND_PREMULTIPLIED)
 
         self.set_image(new_image)
 

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -12,6 +12,7 @@ from pygame_gui._constants import TEXT_EFFECT_FADE_IN, TEXT_EFFECT_FADE_OUT
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core.ui_element import UIElement
 from pygame_gui.core.drawable_shapes import RectDrawableShape, RoundedRectangleShape
+from pygame_gui.core.utility import basic_blit
 
 from pygame_gui.elements.ui_vertical_scroll_bar import UIVerticalScrollBar
 from pygame_gui.elements.text import TextBlock, TextHTMLParser
@@ -249,14 +250,13 @@ class UITextBox(UIElement):
                                      self.text_wrap_rect[3]))
         new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
         new_image.fill(pygame.Color(0, 0, 0, 0))
-        new_image.blit(self.background_surf, (0, 0), special_flags=pygame.BLEND_PREMULTIPLIED)
-        new_image.blit(self.formatted_text_block.block_sprite,
-                       (self.padding[0] + self.border_width +
-                        self.shadow_width + self.rounded_corner_offset,
-                        self.padding[1] + self.border_width +
-                        self.shadow_width + self.rounded_corner_offset),
-                       drawable_area,
-                       special_flags=pygame.BLEND_PREMULTIPLIED)
+        basic_blit(new_image, self.background_surf, (0, 0))
+        basic_blit(new_image, self.formatted_text_block.block_sprite,
+                   (self.padding[0] + self.border_width +
+                    self.shadow_width + self.rounded_corner_offset,
+                    self.padding[1] + self.border_width +
+                    self.shadow_width + self.rounded_corner_offset),
+                   drawable_area)
 
         self.set_image(new_image)
 
@@ -288,17 +288,15 @@ class UITextBox(UIElement):
 
             new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
             new_image.fill(pygame.Color(0, 0, 0, 0))
-            new_image.blit(self.background_surf, (0, 0),
-                           special_flags=pygame.BLEND_PREMULTIPLIED)
-            new_image.blit(self.formatted_text_block.block_sprite,
-                           (self.padding[0] + self.border_width +
-                            self.shadow_width +
-                            self.rounded_corner_offset,
-                            self.padding[1] + self.border_width +
-                            self.shadow_width +
-                            self.rounded_corner_offset),
-                           drawable_area,
-                           special_flags=pygame.BLEND_PREMULTIPLIED)
+            basic_blit(new_image, self.background_surf, (0, 0))
+            basic_blit(new_image, self.formatted_text_block.block_sprite,
+                       (self.padding[0] + self.border_width +
+                        self.shadow_width +
+                        self.rounded_corner_offset,
+                        self.padding[1] + self.border_width +
+                        self.shadow_width +
+                        self.rounded_corner_offset),
+                       drawable_area)
             self.set_image(new_image)
 
         mouse_x, mouse_y = self.ui_manager.get_mouse_position()
@@ -424,8 +422,7 @@ class UITextBox(UIElement):
                                                flags=pygame.SRCALPHA,
                                                depth=32)
                     new_image.fill(pygame.Color('#00000000'))
-                    new_image.blit(self.image, (0, 0),
-                                   special_flags=pygame.BLEND_PREMULTIPLIED)
+                    basic_blit(new_image, self.image, (0, 0))
                     self.set_image(new_image)
 
                     if self.scroll_bar is not None:
@@ -478,16 +475,13 @@ class UITextBox(UIElement):
                                     (self.text_wrap_rect[2], self.text_wrap_rect[3]))
         new_image = pygame.Surface(self.rect.size, flags=pygame.SRCALPHA, depth=32)
         new_image.fill(pygame.Color(0, 0, 0, 0))
-        new_image.blit(self.background_surf, (0, 0),
-                       special_flags=pygame.BLEND_PREMULTIPLIED)
-        new_image.blit(self.formatted_text_block.block_sprite,
-                       (self.padding[0] + self.border_width +
-                        self.shadow_width + self.rounded_corner_offset,
-                        self.padding[1] + self.border_width +
-                        self.shadow_width + self.rounded_corner_offset),
-                       drawable_area,
-                       special_flags=pygame.BLEND_PREMULTIPLIED)
-
+        basic_blit(new_image, self.background_surf, (0, 0))
+        basic_blit(new_image, self.formatted_text_block.block_sprite,
+                   (self.padding[0] + self.border_width +
+                    self.shadow_width + self.rounded_corner_offset,
+                    self.padding[1] + self.border_width +
+                    self.shadow_width + self.rounded_corner_offset),
+                   drawable_area)
         self.set_image(new_image)
 
     def redraw_from_chunks(self):

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -91,7 +91,7 @@ class UITextEntryLine(UIElement):
         self.selected_text_colour = None
         self.selected_bg_colour = None
         self.border_colour = None
-        self.padding = None
+        self.padding = (0, 0)
 
         self.drawable_shape = None
         self.shape = 'rectangle'

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -51,7 +51,7 @@ class UIManager(IUIManagerInterface):
             self.ui_theme.load_theme(theme_path)
 
         self.universal_empty_surface = pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)
-        self.ui_group = pygame.sprite.LayeredUpdates()
+        self.ui_group = pygame.sprite.LayeredDirty()
 
         self.focused_element = None
         self.last_focused_vertical_scrollbar = None
@@ -109,7 +109,7 @@ class UIManager(IUIManagerInterface):
         """
         return self.ui_theme
 
-    def get_sprite_group(self) -> pygame.sprite.LayeredUpdates:
+    def get_sprite_group(self) -> pygame.sprite.LayeredDirty:
         """
         Gets the sprite group used by the entire UI to keep it in the correct order for drawing and
         processing input.
@@ -522,10 +522,14 @@ class UIManager(IUIManagerInterface):
         """
         Wrapping pygame mouse position so we can mess with it.
         """
-        mouse_x, mouse_y = pygame.mouse.get_pos()
+        self.mouse_position = self.calculate_scaled_mouse_position(pygame.mouse.get_pos())
 
-        self.mouse_position = (int(self.mouse_pos_scale_factor[0] * mouse_x),
-                               int(self.mouse_pos_scale_factor[1] * mouse_y))
+    def calculate_scaled_mouse_position(self, position: Tuple[int, int]) -> Tuple[int, int]:
+        """
+        Scaling an input mouse position by a scale factor.
+        """
+        return (int(self.mouse_pos_scale_factor[0] * position[0]),
+                int(self.mouse_pos_scale_factor[1] * position[1]))
 
     def _load_default_cursors(self):
         """

--- a/pygame_gui/windows/ui_colour_picker_dialog.py
+++ b/pygame_gui/windows/ui_colour_picker_dialog.py
@@ -331,7 +331,8 @@ class UIColourPickerDialog(UIWindow):
                          'channel_spacing': 11,
                          'channel_height': 29}
 
-        current_colour_surface = pygame.Surface((64, 64))
+        current_colour_surface = pygame.Surface((64, 64),
+                                                flags=pygame.SRCALPHA, depth=32)
         current_colour_surface.fill(self.current_colour)
 
         self.current_colour_image = UIImage(pygame.Rect(default_sizes['element_spacing'],
@@ -347,7 +348,7 @@ class UIColourPickerDialog(UIWindow):
                                                      'bottom': 'bottom'}
                                             )
 
-        mini_colour_surf = pygame.Surface((2, 2))
+        mini_colour_surf = pygame.Surface((2, 2), flags=pygame.SRCALPHA, depth=32)
         mini_colour_surf.fill(pygame.Color(0, 0, 0, 255), pygame.Rect(0, 0, 1, 2))
         mini_colour_surf.fill(pygame.Color(255, 255, 255, 255), pygame.Rect(1, 1, 1, 1))
 
@@ -543,7 +544,7 @@ class UIColourPickerDialog(UIWindow):
         Updates the 'current colour' image when the current colour has been changed.
 
         """
-        current_colour_surface = pygame.Surface((64, 64))
+        current_colour_surface = pygame.Surface((64, 64), flags=pygame.SRCALPHA, depth=32)
         current_colour_surface.fill(self.current_colour)
         self.current_colour_image.set_image(current_colour_surface)
 
@@ -559,7 +560,7 @@ class UIColourPickerDialog(UIWindow):
         And then using the smoothscale transform to enlarge it so that the colours blend smoothly
         from one to the other.
         """
-        mini_colour_surf = pygame.Surface((2, 2))
+        mini_colour_surf = pygame.Surface((2, 2), flags=pygame.SRCALPHA, depth=32)
         mini_colour_surf.fill(pygame.Color(0, 0, 0, 255), pygame.Rect(0, 0, 1, 2))
         mini_colour_surf.fill(pygame.Color(255, 255, 255, 255), pygame.Rect(1, 1, 1, 1))
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class DevelopOnlyInstall(develop):
 setup(
       cmdclass={'develop': DevelopOnlyInstall},
       name='pygame_gui',
-      version='0.5.6',
+      version='0.5.7',
       description='A GUI module for pygame 2',
       long_description="Helps create GUIs for games made using pygame 2. "
                        "Features HTML-style text formatting, "

--- a/tests/test_core/test_drawable_shapes/test_drawable_shape.py
+++ b/tests/test_core/test_drawable_shapes/test_drawable_shape.py
@@ -5,6 +5,7 @@ from tests.shared_fixtures import _init_pygame, default_ui_manager, default_disp
 
 from pygame_gui.core.drawable_shapes.drawable_shape import DrawableShape, DrawableShapeState, DrawableStateTransition
 from pygame_gui.ui_manager import UIManager
+from pygame_gui.core.utility import apply_colour_to_surface
 
 
 class TestDrawableShapeState:
@@ -193,8 +194,7 @@ class TestDrawableShape:
         test_surface = pygame.Surface((50, 50), flags=pygame.SRCALPHA, depth=32)
         test_surface.fill(pygame.Color(255,255,255,255))
 
-        shape.apply_colour_to_surface(pygame.Color(50, 100, 50, 255),
-                                      test_surface)
+        apply_colour_to_surface(pygame.Color(50, 100, 50, 255), test_surface)
 
         after_application_colour = test_surface.get_at((0, 0))
 
@@ -204,9 +204,8 @@ class TestDrawableShape:
         test_surface_2 = pygame.Surface((50, 50), flags=pygame.SRCALPHA, depth=32)
         test_surface_2.fill(pygame.Color(255, 255, 255, 255))
 
-        shape.apply_colour_to_surface(pygame.Color(150, 100, 150, 255),
-                                      test_surface_2,
-                                      pygame.Rect(0, 0, 25, 50))
+        apply_colour_to_surface(pygame.Color(150, 100, 150, 255), test_surface_2,
+                                pygame.Rect(0, 0, 25, 50))
 
         after_application_colour = test_surface_2.get_at((0, 0))
 

--- a/tests/test_elements/test_text/test_styled_chunk.py
+++ b/tests/test_elements/test_text/test_styled_chunk.py
@@ -13,7 +13,7 @@ from pygame_gui.core.resource_loaders import BlockingThreadedResourceLoader
 
 
 class TestStyledChunk:
-    def test_creation(self, _init_pygame):
+    def test_creation(self, _init_pygame, _display_surface_return_none):
         dictionary = UIFontDictionary(BlockingThreadedResourceLoader())
         style = CharStyle()
         StyledChunk(font_size=14, font_name='fira_code',

--- a/tests/test_elements/test_text/test_text_block.py
+++ b/tests/test_elements/test_text/test_text_block.py
@@ -13,8 +13,9 @@ from pygame_gui.elements.text.text_block import TextBlock
 from pygame_gui.core.ui_font_dictionary import UIFontDictionary
 from pygame_gui.core import BlockingThreadedResourceLoader
 
+
 class TestTextBlock:
-    def test_creation(self, _init_pygame):
+    def test_creation(self, _init_pygame, _display_surface_return_none):
         dictionary = UIFontDictionary(BlockingThreadedResourceLoader())
         style = CharStyle()
         styled_chunk = StyledChunk(font_size=14, font_name='fira_code',
@@ -27,7 +28,7 @@ class TestTextBlock:
                   indexed_styles={0: styled_chunk}, font_dict=dictionary, link_style=style,
                   bg_colour=pygame.Color('#FF0000'), wrap_to_height=True)
 
-    def test_creation_scale_to_text(self, _init_pygame):
+    def test_creation_scale_to_text(self, _init_pygame, _display_surface_return_none):
         dictionary = UIFontDictionary(BlockingThreadedResourceLoader())
         style = CharStyle()
         styled_chunk = StyledChunk(font_size=14, font_name='fira_code',
@@ -40,7 +41,7 @@ class TestTextBlock:
                   indexed_styles={0: styled_chunk}, font_dict=dictionary, link_style=style,
                   bg_colour=pygame.Color('#FF0000'), wrap_to_height=True)
 
-    def test_creation_scale_vert_to_text(self, _init_pygame):
+    def test_creation_scale_vert_to_text(self, _init_pygame, _display_surface_return_none):
         dictionary = UIFontDictionary(BlockingThreadedResourceLoader())
         style = CharStyle()
         styled_chunk = StyledChunk(font_size=14, font_name='fira_code',
@@ -53,7 +54,7 @@ class TestTextBlock:
                   indexed_styles={0: styled_chunk}, font_dict=dictionary, link_style=style,
                   bg_colour=pygame.Color('#FF0000'), wrap_to_height=True)
 
-    def test_word_split(self, _init_pygame):
+    def test_word_split(self, _init_pygame, _display_surface_return_none):
         loader = BlockingThreadedResourceLoader()
         dictionary = UIFontDictionary(loader)
         dictionary.preload_font(font_size=25, font_name='fira_code')

--- a/tests/test_elements/test_ui_label.py
+++ b/tests/test_elements/test_ui_label.py
@@ -11,20 +11,23 @@ from pygame_gui.core.ui_container import UIContainer
 
 class TestUILabel:
 
-    def test_creation(self, _init_pygame, default_ui_manager):
+    def test_creation(self, _init_pygame, default_ui_manager,
+                      _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=default_ui_manager)
         assert label.image is not None
 
-    def test_set_text(self, _init_pygame, default_ui_manager):
+    def test_set_text(self, _init_pygame, default_ui_manager,
+                      _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=default_ui_manager)
         label.set_text("new text")
         assert label.image is not None
 
-    def test_rebuild(self, _init_pygame, default_ui_manager):
+    def test_rebuild(self, _init_pygame, default_ui_manager,
+                     _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=default_ui_manager)
@@ -32,21 +35,24 @@ class TestUILabel:
         assert label.image is not None
 
     def test_rebuild_from_theme_data_non_default_1(self, _init_pygame):
-        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_label_non_default_1.json"))
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes",
+                                                     "ui_label_non_default_1.json"))
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=manager)
         assert label.image is not None
 
     def test_rebuild_from_theme_data_non_default_2(self, _init_pygame):
-        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_label_non_default_2.json"))
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes",
+                                                     "ui_label_non_default_2.json"))
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=manager)
         assert label.image is not None
 
     def test_rebuild_from_theme_data_non_default_3(self, _init_pygame):
-        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_label_non_default_3.json"))
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes",
+                                                     "ui_label_non_default_3.json"))
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=manager)
@@ -56,14 +62,17 @@ class TestUILabel:
     @pytest.mark.filterwarnings("ignore:Colour hex code")
     @pytest.mark.filterwarnings("ignore:Label Rect is too small for text")
     def test_rebuild_from_theme_data_bad_values(self, _init_pygame):
-        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_label_bad_values.json"))
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes",
+                                                     "ui_label_bad_values.json"))
         label = UILabel(relative_rect=pygame.Rect(100, 100, 10, 30),
                         text="Test Label",
                         manager=manager)
         assert label.image is not None
 
-    def test_set_position(self, _init_pygame, default_ui_manager):
-        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60), manager=default_ui_manager)
+    def test_set_position(self, _init_pygame, default_ui_manager,
+                          _display_surface_return_none):
+        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60),
+                                     manager=default_ui_manager)
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         container=test_container,
@@ -73,8 +82,10 @@ class TestUILabel:
 
         assert label.relative_rect.topleft == (50, -70)
 
-    def test_set_relative_position(self, _init_pygame, default_ui_manager):
-        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60), manager=default_ui_manager)
+    def test_set_relative_position(self, _init_pygame, default_ui_manager,
+                                   _display_surface_return_none):
+        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60),
+                                     manager=default_ui_manager)
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         container=test_container,
@@ -84,8 +95,10 @@ class TestUILabel:
 
         assert label.rect.topleft == (150, 150)
 
-    def test_set_dimensions(self, _init_pygame, default_ui_manager):
-        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60), manager=default_ui_manager)
+    def test_set_dimensions(self, _init_pygame, default_ui_manager,
+                            _display_surface_return_none):
+        test_container = UIContainer(relative_rect=pygame.Rect(100, 100, 300, 60),
+                                     manager=default_ui_manager)
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         container=test_container,

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -46,7 +46,7 @@ class TestUITextEntryLine:
 
         assert text_entry.get_text() == "GOLD"
 
-    def test_set_text_forbidden_characters(self, _init_pygame, default_ui_manager):
+    def test_set_text_forbidden_characters(self, _init_pygame, default_ui_manager,):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager)
 
@@ -54,7 +54,8 @@ class TestUITextEntryLine:
         with pytest.warns(UserWarning, match="Tried to set text string with invalid characters on text entry element"):
             text_entry.set_text("1,2,3,4,5")
 
-    def test_rebuild_select_area_1(self, _init_pygame, default_ui_manager):
+    def test_rebuild_select_area_1(self, _init_pygame, default_ui_manager,
+                                   _display_surface_return_none):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager)
 
@@ -64,7 +65,8 @@ class TestUITextEntryLine:
 
         assert text_entry.image is not None
 
-    def test_set_text_rebuild_select_area_2(self, _init_pygame):
+    def test_set_text_rebuild_select_area_2(self, _init_pygame,
+                                            _display_surface_return_none):
         manager = UIManager((800, 600), os.path.join("tests", "data",
                                                      "themes", "ui_text_entry_line_non_default.json"))
 
@@ -117,7 +119,7 @@ class TestUITextEntryLine:
 
         assert text_entry.image is not None
 
-    def test_focus(self, _init_pygame, default_ui_manager):
+    def test_focus(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager)
 
@@ -125,7 +127,7 @@ class TestUITextEntryLine:
 
         assert text_entry.image is not None
 
-    def test_unfocus(self, _init_pygame, default_ui_manager):
+    def test_unfocus(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager)
 

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -403,7 +403,9 @@ class TestUITextEntryLine:
         processed_up_event = text_entry.process_event(pygame.event.Event(pygame.MOUSEBUTTONUP,
                                                                          {'button': 1, 'pos': (80, 15)}))
 
-        assert (processed_down_event and processed_up_event and text_entry.select_range == [3, 9])
+        assert processed_down_event
+        assert processed_up_event
+        assert text_entry.select_range == [3, 9]
 
     def test_process_event_mouse_button_double_click(self, _init_pygame: None, default_ui_manager: UIManager,
                                                      _display_surface_return_none: None):

--- a/tests/test_elements/test_ui_tool_tip.py
+++ b/tests/test_elements/test_ui_tool_tip.py
@@ -2,7 +2,8 @@ import os
 import pytest
 import pygame
 
-from tests.shared_fixtures import _init_pygame, default_ui_manager, default_display_surface
+from tests.shared_fixtures import _init_pygame, default_ui_manager
+from tests.shared_fixtures import default_display_surface, _display_surface_return_none
 
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.elements.ui_tool_tip import UITooltip
@@ -10,27 +11,28 @@ from pygame_gui.elements.ui_tool_tip import UITooltip
 
 class TestUIToolTip:
 
-    def test_creation(self, _init_pygame, default_ui_manager):
+    def test_creation(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
         assert tool_tip.text_block.image is not None
 
-    def test_rebuild(self, _init_pygame, default_ui_manager):
+    def test_rebuild(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
         tool_tip.rebuild()
         assert tool_tip.text_block.image is not None
 
-    def test_kill(self, _init_pygame, default_ui_manager):
+    def test_kill(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
         tool_tip.kill()
         assert tool_tip.alive() is False and tool_tip.text_block.alive() is False
 
-    def test_find_valid_position(self, _init_pygame, default_ui_manager: UIManager):
+    def test_find_valid_position(self, _init_pygame, default_ui_manager: UIManager,
+                                 _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -40,7 +42,8 @@ class TestUIToolTip:
         assert found_position is True
 
     @pytest.mark.filterwarnings("ignore:initial position for tool tip is off screen")
-    def test_find_invalid_position(self, _init_pygame, default_ui_manager: UIManager):
+    def test_find_invalid_position(self, _init_pygame, default_ui_manager: UIManager,
+                                   _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -49,7 +52,8 @@ class TestUIToolTip:
 
         assert found_position is False
 
-    def test_find_valid_position_off_bottom(self, _init_pygame, default_ui_manager: UIManager):
+    def test_find_valid_position_off_bottom(self, _init_pygame, default_ui_manager: UIManager,
+                                            _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -60,7 +64,8 @@ class TestUIToolTip:
 
         assert found_position is True and bool(root_window_rect.contains(tool_tip.rect)) is True
 
-    def test_find_valid_position_off_right(self, _init_pygame, default_ui_manager: UIManager):
+    def test_find_valid_position_off_right(self, _init_pygame, default_ui_manager: UIManager,
+                                           _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -71,7 +76,8 @@ class TestUIToolTip:
 
         assert found_position is True and bool(root_window_rect.contains(tool_tip.rect)) is True
 
-    def test_find_valid_position_off_left(self, _init_pygame, default_ui_manager: UIManager):
+    def test_find_valid_position_off_left(self, _init_pygame, default_ui_manager: UIManager,
+                                          _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -83,7 +89,8 @@ class TestUIToolTip:
         assert found_position is True and bool(root_window_rect.contains(tool_tip.rect)) is True
 
     @pytest.mark.filterwarnings("ignore:Unable to fit tool tip on screen")
-    def test_find_valid_position_screen_too_small(self, _init_pygame):
+    def test_find_valid_position_screen_too_small(self, _init_pygame,
+                                                  _display_surface_return_none):
         manager = UIManager((50, 50))
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
@@ -95,7 +102,8 @@ class TestUIToolTip:
 
         assert found_position is False and bool(root_window_rect.contains(tool_tip.rect)) is False
 
-    def test_non_default_theme_build(self, _init_pygame):
+    def test_non_default_theme_build(self, _init_pygame,
+                                     _display_surface_return_none):
         manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_tool_tip_non_default.json"))
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
@@ -104,7 +112,8 @@ class TestUIToolTip:
         assert tool_tip.text_block.image is not None
 
     @pytest.mark.filterwarnings("ignore:Invalid value")
-    def test_bad_values_theme_build(self, _init_pygame):
+    def test_bad_values_theme_build(self, _init_pygame,
+                                    _display_surface_return_none):
         manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_tool_tip_bad_values.json"))
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
@@ -112,7 +121,8 @@ class TestUIToolTip:
 
         assert tool_tip.text_block.image is not None
 
-    def test_set_position(self, _init_pygame, default_ui_manager):
+    def test_set_position(self, _init_pygame, default_ui_manager,
+                          _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -121,7 +131,8 @@ class TestUIToolTip:
 
         assert tool_tip.rect.topleft == (150, 30) and tool_tip.text_block.rect.topleft == (150, 30)
 
-    def test_set_relative_position(self, _init_pygame, default_ui_manager):
+    def test_set_relative_position(self, _init_pygame, default_ui_manager,
+                                   _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
@@ -135,7 +146,8 @@ class TestUIToolTip:
 
         assert tool_tip.text_block.rect.topleft == (150, 30)
 
-    def test_set_dimensions(self, _init_pygame, default_ui_manager):
+    def test_set_dimensions(self, _init_pygame, default_ui_manager,
+                            _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",
                              hover_distance=(0, 10),
                              manager=default_ui_manager)

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -37,7 +37,7 @@ class TestUIManager:
         Can we get the sprite group? Serves as a test of the sprite group being successfully created.
         """
         sprite_group = default_ui_manager.get_sprite_group()
-        assert(type(sprite_group) == pygame.sprite.LayeredUpdates)
+        assert(type(sprite_group) == pygame.sprite.LayeredDirty)
 
     def test_get_window_stack(self, _init_pygame, default_ui_manager):
         """

--- a/tests/test_windows/test_ui_colour_picker_dialog.py
+++ b/tests/test_windows/test_ui_colour_picker_dialog.py
@@ -10,6 +10,7 @@ from pygame_gui.ui_manager import UIManager
 from pygame_gui.core.ui_container import UIContainer
 from pygame_gui.windows import UIColourPickerDialog
 from pygame_gui.windows.ui_colour_picker_dialog import UIColourChannelEditor
+from pygame_gui.core.utility import restore_premul_col
 
 try:
     # mouse button constants not defined in pygame 1.9.3
@@ -278,7 +279,12 @@ class TestUIColourPickerDialog:
         pixel_colour = colour_picker.current_colour_image.image.get_at((int(colour_picker.current_colour_image.rect.width/2),
                                                                         int(colour_picker.current_colour_image.rect.height/2)))
 
-        assert pixel_colour == pygame.Color(200, 220, 50, 255)
+        pixel_colour = restore_premul_col(pixel_colour)  # this is going to be slightly inaccurate
+
+        assert 201 >= pixel_colour.r >= 199
+        assert 221 >= pixel_colour.g >= 219
+        assert 51 >= pixel_colour.b >= 49
+        assert pixel_colour.a == 255
 
         colour_picker.current_colour = pygame.Color(50, 180, 150, 255)
         colour_picker.update_current_colour_image()
@@ -287,7 +293,12 @@ class TestUIColourPickerDialog:
             (int(colour_picker.current_colour_image.rect.width / 2),
              int(colour_picker.current_colour_image.rect.height / 2)))
 
-        assert pixel_colour == pygame.Color(50, 180, 150, 255)
+        pixel_colour = restore_premul_col(pixel_colour)
+
+        assert 51 >= pixel_colour.r >= 49
+        assert 181 >= pixel_colour.g >= 179
+        assert 151 >= pixel_colour.b >= 149
+        assert pixel_colour.a == 255
 
     def test_changed_rgb_update_hsv(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         colour_picker = UIColourPickerDialog(rect=pygame.Rect(100, 100, 400, 400),


### PR DESCRIPTION
Previously Pygame GUI's fancier styling features have not worked properly on pygame 2, which was a shame. However, I managed to track the problem back to a change in how the alpha blend modes work between pygame 1 & 2 and made a fairly involved fix that made it into pygame 2.

Now we use a blending mode called pre-multiplied alpha to draw GUI elements in pygame 2.0.0.dev10. I likely haven't finished tinkering with it yet - and it's probably introduced some bugs but it's time to start merging it into master before I forget how it all works.
