### PR TITLE
Fix overlapping expanded drop down menus.

### DIFF
--- a/pygame_gui/core/interfaces/element_interface.py
+++ b/pygame_gui/core/interfaces/element_interface.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Union, List
+from typing import Tuple, Union, List, Set, Any
 
 import pygame
 
@@ -266,4 +266,34 @@ class IUIElementInterface(metaclass=ABCMeta):
 
         :return: an integer representing the starting layer height.
 
+        """
+
+    @abstractmethod
+    def get_focus_set(self) -> Set[Any]:
+        """
+        Return the set of elements to focus when we focus this element.
+        """
+
+    @abstractmethod
+    def set_focus_set(self, focus_set: Set[Any]):
+        """
+        Set the focus set to a specific set of elements.
+
+        :param focus_set: The focus set to set.
+        """
+
+    @abstractmethod
+    def join_focus_sets(self, element):
+        """
+        Join this element's focus set with another's.
+
+        :param element: The other element whose focus set we are joining with.
+        """
+
+    @abstractmethod
+    def remove_element_from_focus_set(self, element):
+        """
+        remove an element from this sets focus group.
+
+        :param element: The element to remove.
         """

--- a/pygame_gui/core/interfaces/manager_interface.py
+++ b/pygame_gui/core/interfaces/manager_interface.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, List, Union, Dict
+from typing import Tuple, List, Union, Dict, Set
 
 import pygame
 
@@ -162,11 +162,21 @@ class IUIManagerInterface(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def set_focus_element(self, ui_element: IUIElementInterface):
+    def get_focus_set(self) -> Set[IUIElementInterface]:
         """
-        Set an element as the focused element.
+        Gets the focused set.
 
-        :param ui_element: The element to focus on.
+        :return: The set of elements that currently have interactive focus.
+        """
+
+    @abstractmethod
+    def set_focus_set(self, focus: Union[IUIElementInterface, Set[IUIElementInterface]]):
+        """
+        Set a set of element as the focused set.
+
+        If the set is a scroll bar we also keep track of that.
+
+        :param focus: The set of element to focus on.
         """
 
     @abstractmethod

--- a/pygame_gui/core/ui_appearance_theme.py
+++ b/pygame_gui/core/ui_appearance_theme.py
@@ -46,7 +46,7 @@ except ImportError:
             USE_FILE_PATH = True
         else:
             USE_STRINGIFIED_DATA = True
-            from pygame_gui.core._string_data import default_theme  # pylint: disable=ungrouped-imports
+            from pygame_gui.core._string_data import default_theme  # noqa: E501 pylint: disable=ungrouped-imports
     else:
         USE_IMPORT_LIB_RESOURCE = True
 

--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Union, Tuple, Dict, Any, Callable
+from typing import List, Union, Tuple, Dict, Any, Callable, Set
 
 import pygame
 
@@ -97,6 +97,24 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         self._update_absolute_rect_position_from_anchors()
 
         self._update_container_clip()
+
+        self._focus_set = {self}
+
+    def get_focus_set(self) -> Set[Any]:
+        return self._focus_set
+
+    def set_focus_set(self, focus_set: Set[Any]):
+        if self.ui_manager.get_focus_set() is self._focus_set:
+            self.ui_manager.set_focus_set(focus_set)
+        self._focus_set = focus_set
+
+    def join_focus_sets(self, element):
+        union_of_sets = set(self._focus_set | element.get_focus_set())
+        for item in union_of_sets:
+            item.set_focus_set(union_of_sets)
+
+    def remove_element_from_focus_set(self, element):
+        self._focus_set.discard(element)
 
     def get_relative_rect(self) -> pygame.Rect:
         """
@@ -422,6 +440,7 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         Overriding regular sprite kill() method to remove the element from it's container.
         """
         self.ui_container.remove_element(self)
+        self.remove_element_from_focus_set(self)
         super().kill()
 
     def check_hover(self, time_delta: float, hovered_higher_element: bool) -> bool:

--- a/pygame_gui/elements/ui_drop_down_menu.py
+++ b/pygame_gui/elements/ui_drop_down_menu.py
@@ -124,6 +124,7 @@ class UIExpandedDropDownState:
                                                starting_height=2,
                                                parent_element=self.drop_down_menu_ui,
                                                object_id='#selected_option')
+        self.drop_down_menu_ui.join_focus_sets(self.selected_option_button)
 
         expand_button_symbol = '▼'
 
@@ -191,18 +192,22 @@ class UIExpandedDropDownState:
                                      starting_height=2,
                                      parent_element=self.drop_down_menu_ui,
                                      object_id='#expand_button')
+        self.drop_down_menu_ui.join_focus_sets(self.close_button)
+
         list_rect = pygame.Rect(self.drop_down_menu_ui.relative_rect.left,
                                 self.option_list_y_pos,
                                 (self.drop_down_menu_ui.relative_rect.width -
                                  self.close_button_width),
                                 self.options_list_height)
         self.options_selection_list = UISelectionList(list_rect,
+                                                      starting_height=2,
                                                       item_list=self.options_list,
                                                       allow_double_clicks=False,
                                                       manager=self.ui_manager,
                                                       parent_element=self.drop_down_menu_ui,
                                                       container=self.ui_container,
                                                       object_id='#drop_down_options_list')
+        self.drop_down_menu_ui.join_focus_sets(self.options_selection_list)
 
         self.rebuild()
 
@@ -428,6 +433,8 @@ class UIClosedDropDownState:
                                                starting_height=2,
                                                parent_element=self.drop_down_menu_ui,
                                                object_id='#selected_option')
+        self.drop_down_menu_ui.join_focus_sets(self.selected_option_button)
+
         open_button_x = (self.base_position_rect.x +
                          self.base_position_rect.width -
                          self.open_button_width)
@@ -449,6 +456,7 @@ class UIClosedDropDownState:
                                     starting_height=2,
                                     parent_element=self.drop_down_menu_ui,
                                     object_id='#expand_button')
+        self.drop_down_menu_ui.join_focus_sets(self.open_button)
 
     def finish(self):
         """
@@ -629,6 +637,10 @@ class UIDropDownMenu(UIElement):
         """
         self.current_state.finish()
         super().kill()
+
+    def unfocus(self):
+        if self.current_state is self.menu_states['expanded']:
+            self.current_state.should_transition = True
 
     def update(self, time_delta: float):
         """

--- a/pygame_gui/elements/ui_horizontal_scroll_bar.py
+++ b/pygame_gui/elements/ui_horizontal_scroll_bar.py
@@ -226,7 +226,7 @@ class UIHorizontalScrollBar(UIElement):
         'bar' part of the scroll bar.
         """
         if self.sliding_button is not None:
-            self.ui_manager.set_focus_element(self.sliding_button)
+            self.ui_manager.set_focus_set(self.sliding_button)
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """

--- a/pygame_gui/elements/ui_selection_list.py
+++ b/pygame_gui/elements/ui_selection_list.py
@@ -164,6 +164,7 @@ class UISelectionList(UIElement):
                                                    'right': 'right',
                                                    'top': 'top',
                                                    'bottom': 'top'})
+                        self.join_focus_sets(button)
                         item['button_element'] = button
                         if item['selected']:
                             item['button_element'].select()
@@ -232,6 +233,7 @@ class UISelectionList(UIElement):
                                                                'right': 'right',
                                                                'top': 'top',
                                                                'bottom': 'bottom'})
+                self.join_focus_sets(self.scroll_bar)
         else:
             if self.scroll_bar is not None:
                 self.scroll_bar.kill()
@@ -263,6 +265,7 @@ class UISelectionList(UIElement):
                          'right': 'right',
                          'top': 'top',
                          'bottom': 'bottom'})
+            self.join_focus_sets(self.item_list_container)
         item_y_height = 0
         for item in self.item_list:
             if item_y_height <= self.item_list_container.relative_rect.height:
@@ -280,6 +283,7 @@ class UISelectionList(UIElement):
                                                            'right': 'right',
                                                            'top': 'top',
                                                            'bottom': 'top'})
+                self.join_focus_sets(item['button_element'])
                 item_y_height += self.list_item_height
             else:
                 break
@@ -479,6 +483,7 @@ class UISelectionList(UIElement):
                 parent_element=self._parent_element,
                 object_id='#selection_list_container',
                 anchors=self.anchors)
+            self.join_focus_sets(self.list_and_scroll_bar_container)
         else:
             self.list_and_scroll_bar_container.set_dimensions((self.relative_rect.width -
                                                                (2 * self.shadow_width) -

--- a/pygame_gui/elements/ui_vertical_scroll_bar.py
+++ b/pygame_gui/elements/ui_vertical_scroll_bar.py
@@ -225,7 +225,7 @@ class UIVerticalScrollBar(UIElement):
         'bar' part of the scroll bar.
         """
         if self.sliding_button is not None:
-            self.ui_manager.set_focus_element(self.sliding_button)
+            self.ui_manager.set_focus_set(self.sliding_button)
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Dict, Union
+from typing import Tuple, List, Dict, Union, Set
 
 import pygame
 
@@ -53,7 +53,7 @@ class UIManager(IUIManagerInterface):
         self.universal_empty_surface = pygame.Surface((0, 0), flags=pygame.SRCALPHA, depth=32)
         self.ui_group = pygame.sprite.LayeredDirty()
 
-        self.focused_element = None
+        self.focused_set = None
         self.last_focused_vertical_scrollbar = None
         self.last_focused_horizontal_scrollbar = None
         self.root_container = None
@@ -194,7 +194,7 @@ class UIManager(IUIManagerInterface):
                         mouse_x, mouse_y = event.pos
                         if ui_element.hover_point(mouse_x, mouse_y):
                             # self.unset_focus_element()
-                            self.set_focus_element(ui_element)
+                            self.set_focus_set(ui_element.get_focus_set())
 
                     consumed_event = ui_element.process_event(event)
                     if consumed_event:
@@ -373,29 +373,47 @@ class UIManager(IUIManagerInterface):
         """
         self.ui_theme.get_font_dictionary().print_unused_loaded_fonts()
 
-    def set_focus_element(self, ui_element: IUIElementInterface):
-        """
-        Set an element as the focused element.
+    def get_focus_set(self):
+        return self.focused_set
 
-        If the element is a scroll bar we also keep track of that.
-
-        :param ui_element: The element to focus on.
+    def set_focus_set(self, focus: Union[IUIElementInterface, Set[IUIElementInterface]]):
         """
-        if ui_element is self.focused_element:
+        Set a set of element as the focused set.
+
+        If the set is a scroll bar we also keep track of that.
+
+        :param focus: The set of element to focus on.
+        """
+        if focus is self.focused_set:
             return
-        if self.focused_element is not None:
-            self.focused_element.unfocus()
-            self.focused_element = None
+        if self.focused_set is not None:
+            for item in self.focused_set:
+                if isinstance(focus, set):
+                    if item not in focus:
+                        item.unfocus()
+                    else:
+                        pass  # do nothing in this case because the item is also in new focus set
+                else:
+                    item.unfocus()
+            self.focused_set = None
 
-        if self.focused_element is None:
-            self.focused_element = ui_element
-            if ui_element is not None:
-                self.focused_element.focus()
+        if self.focused_set is None:
+            if focus is not None:
+                if isinstance(focus, IUIElementInterface):
+                    self.focused_set = focus.get_focus_set()
+                elif isinstance(focus, set):
+                    self.focused_set = focus
+            else:
+                self.focused_set = None
 
-                if 'vertical_scroll_bar' in ui_element.get_element_ids():
-                    self.last_focused_vertical_scrollbar = ui_element
-                if 'horizontal_scroll_bar' in ui_element.get_element_ids():
-                    self.last_focused_horizontal_scrollbar = ui_element
+            if self.focused_set is not None:
+                for item in self.focused_set:
+                    item.focus()
+
+                    if 'vertical_scroll_bar' in item.get_element_ids():
+                        self.last_focused_vertical_scrollbar = item
+                    if 'horizontal_scroll_bar' in item.get_element_ids():
+                        self.last_focused_horizontal_scrollbar = item
 
     def clear_last_focused_from_vert_scrollbar(self, vert_scrollbar: IUIElementInterface):
         """

--- a/tests/test_elements/test_ui_button.py
+++ b/tests/test_elements/test_ui_button.py
@@ -327,8 +327,8 @@ class TestUIButton:
                                                                       'pos': (50, 25)}))
 
         assert (
-                    processed_down_event is True and processed_up_event is True and button.held is False and
-                    button.pressed_event is True and default_ui_manager.focused_element is None)
+                processed_down_event is True and processed_up_event is True and button.held is False and
+                button.pressed_event is True and default_ui_manager.focused_set is None)
 
     def test_process_event_mouse_button_up_outside(self, _init_pygame: None,
                                                    default_ui_manager: UIManager,

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -266,9 +266,9 @@ class TestUIManager:
         """
         test_button = UIButton(relative_rect=pygame.Rect(100, 100, 150, 30),
                                text="Test", manager=default_ui_manager)
-        default_ui_manager.set_focus_element(test_button)
+        default_ui_manager.set_focus_set(test_button)
         was_selected_correctly = test_button.is_focused
-        default_ui_manager.set_focus_element(None)
+        default_ui_manager.set_focus_set(None)
         assert was_selected_correctly is True and test_button.is_focused is False
 
     def test_last_focus_vert_scrollbar(self, _init_pygame, default_ui_manager,
@@ -277,7 +277,7 @@ class TestUIManager:
                                               visible_percentage=0.5,
                                               manager=default_ui_manager)
 
-        default_ui_manager.set_focus_element(test_scroll_bar)
+        default_ui_manager.set_focus_set(test_scroll_bar)
         found_bar = test_scroll_bar is default_ui_manager.get_last_focused_vert_scrollbar()
         default_ui_manager.clear_last_focused_from_vert_scrollbar(test_scroll_bar)
         no_last_focused_scroll_bar = default_ui_manager.get_last_focused_vert_scrollbar() is None


### PR DESCRIPTION
I figured out a slightly easier/better solution than my initial plan which was over-complex.

Basically, now drop down menus will close if you interact with another UI element. I've also started work on a more complex conception of 'focus' by defining it as a set of elements. I'm hoping this will make it easy to glue more complicated UIElements, the ones that are composed of other UIElements, together into one focus-able unit - at least where it seems to makes sense. I think this is a slightly more fuzzy idea that I may have to tinker with a little to get right.
