### PR TITLE
Expand the new concept of focus sets to also include scroll bars

### DIFF
--- a/pygame_gui/elements/ui_drop_down_menu.py
+++ b/pygame_gui/elements/ui_drop_down_menu.py
@@ -639,6 +639,7 @@ class UIDropDownMenu(UIElement):
         super().kill()
 
     def unfocus(self):
+        super().unfocus()
         if self.current_state is self.menu_states['expanded']:
             self.current_state.should_transition = True
 

--- a/pygame_gui/elements/ui_horizontal_scroll_bar.py
+++ b/pygame_gui/elements/ui_horizontal_scroll_bar.py
@@ -97,6 +97,7 @@ class UIHorizontalScrollBar(UIElement):
                                                 'right': 'left',
                                                 'top': 'top',
                                                 'bottom': 'bottom'})
+        self.join_focus_sets(self.sliding_button)
 
         self.sliding_button.set_hold_range((self.background_rect.width, 100))
 
@@ -132,6 +133,7 @@ class UIHorizontalScrollBar(UIElement):
                                                 container=self.ui_container,
                                                 anchors=self.anchors,
                                                 object_id='#horiz_scrollbar_buttons_container')
+            self.join_focus_sets(self.button_container)
         else:
             self.button_container.set_dimensions(self.background_rect.size)
             self.button_container.set_relative_position(self.background_rect.topleft)
@@ -153,6 +155,7 @@ class UIHorizontalScrollBar(UIElement):
                                                      'top': 'top',
                                                      'bottom': 'bottom'}
                                             )
+                self.join_focus_sets(self.left_button)
 
             if self.right_button is None:
                 self.right_button = UIButton(pygame.Rect((-self.arrow_button_width, 0),
@@ -167,6 +170,7 @@ class UIHorizontalScrollBar(UIElement):
                                                       'right': 'right',
                                                       'top': 'top',
                                                       'bottom': 'bottom'})
+                self.join_focus_sets(self.right_button)
         else:
             self.arrow_button_width = 0
             if self.left_button is not None:
@@ -219,14 +223,6 @@ class UIHorizontalScrollBar(UIElement):
 
         self.button_container.kill()
         super().kill()
-
-    def focus(self):
-        """
-        When we focus  the scroll bar as a whole for any reason we pass that status down to the
-        'bar' part of the scroll bar.
-        """
-        if self.sliding_button is not None:
-            self.ui_manager.set_focus_set(self.sliding_button)
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """
@@ -289,9 +285,8 @@ class UIHorizontalScrollBar(UIElement):
         self.has_moved_recently = False
         if self.alive():
             moved_this_frame = False
-            if (self.left_button is not None and
-                    (self.left_button.held or self.scroll_wheel_left) and
-                    self.scroll_position > self.left_limit):
+            if ((self.left_button is not None and self.left_button.held) or
+                    (self.scroll_wheel_left and self.scroll_position > self.left_limit)):
                 self.scroll_wheel_left = False
                 self.scroll_position -= (250.0 * time_delta)
                 self.scroll_position = max(self.scroll_position, self.left_limit)
@@ -299,9 +294,8 @@ class UIHorizontalScrollBar(UIElement):
                 y_pos = 0
                 self.sliding_button.set_relative_position((x_pos, y_pos))
                 moved_this_frame = True
-            elif (self.right_button is not None and
-                  (self.right_button.held or self.scroll_wheel_right) and
-                  self.scroll_position < self.right_limit):
+            elif ((self.right_button is not None and self.right_button.held) or
+                  (self.scroll_wheel_right and self.scroll_position < self.right_limit)):
                 self.scroll_wheel_right = False
                 self.scroll_position += (250.0 * time_delta)
                 self.scroll_position = min(self.scroll_position,
@@ -369,6 +363,7 @@ class UIHorizontalScrollBar(UIElement):
                                                     'right': 'left',
                                                     'top': 'top',
                                                     'bottom': 'bottom'})
+            self.join_focus_sets(self.sliding_button)
 
         else:
             self.sliding_button.set_relative_position(self.sliding_rect_position)

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -217,6 +217,7 @@ class UITextBox(UIElement):
                                                       self.ui_manager,
                                                       self.ui_container,
                                                       parent_element=self)
+                self.join_focus_sets(self.scroll_bar)
             else:
                 new_dimensions = (self.rect[2], self.rect[3])
                 self.set_dimensions(new_dimensions)
@@ -510,15 +511,6 @@ class UITextBox(UIElement):
         self.redraw_from_text_block()
         self.link_hover_chunks = []
         self.formatted_text_block.add_chunks_to_hover_group(self.link_hover_chunks)
-
-    def focus(self):
-        """
-        Called when we focus the text box (usually by clicking on it). In this case we just pass
-        the focus over to the box's scroll bar, if it has one, so that some input events will be
-        directed that way.
-        """
-        if self.scroll_bar is not None:
-            self.scroll_bar.focus()
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -69,8 +69,6 @@ class UITextEntryLine(UIElement):
                                object_id=object_id,
                                element_id='text_entry_line')
 
-        self.focused = False
-
         self.text = ""
 
         # theme font
@@ -423,7 +421,7 @@ class UITextEntryLine(UIElement):
                 if self.cursor_on:
                     self.cursor_on = False
                     self.redraw_cursor()
-                elif self.focused:
+                elif self.is_focused:
                     self.cursor_on = True
                     self.redraw_cursor()
             else:
@@ -435,7 +433,7 @@ class UITextEntryLine(UIElement):
         """
         Called when this element is no longer the current focus.
         """
-        self.focused = False
+        super().unfocus()
         pygame.key.set_repeat(0)
         self.select_range = [0, 0]
         self.edit_position = 0
@@ -447,7 +445,7 @@ class UITextEntryLine(UIElement):
         Called when we 'select focus' on this element. In this case it sets up the keyboard to
         repeat held key presses, useful for natural feeling keyboard input.
         """
-        self.focused = True
+        super().focus()
         pygame.key.set_repeat(500, 25)
         self.redraw()
 
@@ -468,7 +466,7 @@ class UITextEntryLine(UIElement):
         initial_text_state = self.text
         if self._process_mouse_button_event(event):
             consumed_event = True
-        if self.focused and event.type == pygame.KEYDOWN:
+        if self.is_focused and event.type == pygame.KEYDOWN:
             if self._process_keyboard_shortcut_event(event):
                 consumed_event = True
             elif self._process_action_key_event(event):

--- a/pygame_gui/elements/ui_vertical_scroll_bar.py
+++ b/pygame_gui/elements/ui_vertical_scroll_bar.py
@@ -96,7 +96,7 @@ class UIVerticalScrollBar(UIElement):
                                                 'right': 'right',
                                                 'top': 'top',
                                                 'bottom': 'top'})
-
+        self.join_focus_sets(self.sliding_button)
         self.sliding_button.set_hold_range((100, self.background_rect.height))
 
     def rebuild(self):
@@ -131,6 +131,7 @@ class UIVerticalScrollBar(UIElement):
                                                 container=self.ui_container,
                                                 anchors=self.anchors,
                                                 object_id='#vert_scrollbar_buttons_container')
+            self.join_focus_sets(self.button_container)
         else:
             self.button_container.set_dimensions(self.background_rect.size)
             self.button_container.set_relative_position(self.background_rect.topleft)
@@ -152,6 +153,7 @@ class UIVerticalScrollBar(UIElement):
                                                     'top': 'top',
                                                     'bottom': 'top'}
                                            )
+                self.join_focus_sets(self.top_button)
 
             if self.bottom_button is None:
                 self.bottom_button = UIButton(pygame.Rect((0, -self.arrow_button_height),
@@ -166,6 +168,7 @@ class UIVerticalScrollBar(UIElement):
                                                        'right': 'right',
                                                        'top': 'bottom',
                                                        'bottom': 'bottom'})
+                self.join_focus_sets(self.bottom_button)
         else:
             self.arrow_button_height = 0
             if self.top_button is not None:
@@ -219,14 +222,6 @@ class UIVerticalScrollBar(UIElement):
         self.button_container.kill()
         super().kill()
 
-    def focus(self):
-        """
-        When we focus  the scroll bar as a whole for any reason we pass that status down to the
-        'bar' part of the scroll bar.
-        """
-        if self.sliding_button is not None:
-            self.ui_manager.set_focus_set(self.sliding_button)
-
     def process_event(self, event: pygame.event.Event) -> bool:
         """
         Checks an event from pygame's event queue to see if the scroll bar needs to react to it.
@@ -266,10 +261,7 @@ class UIVerticalScrollBar(UIElement):
         """
         last_focused_scrollbar_element = self.ui_manager.get_last_focused_vert_scrollbar()
         return (last_focused_scrollbar_element is not None and
-                ((last_focused_scrollbar_element is self) or
-                 (last_focused_scrollbar_element is self.sliding_button) or
-                 (last_focused_scrollbar_element is self.top_button) or
-                 (last_focused_scrollbar_element is self.bottom_button)))
+                last_focused_scrollbar_element is self)
 
     def update(self, time_delta: float):
         """
@@ -288,8 +280,8 @@ class UIVerticalScrollBar(UIElement):
         self.has_moved_recently = False
         if self.alive():
             moved_this_frame = False
-            if (self.top_button is not None and (self.top_button.held or self.scroll_wheel_up) and
-                    self.scroll_position > self.top_limit):
+            if ((self.top_button is not None and self.top_button.held) or
+                    (self.scroll_wheel_up and self.scroll_position > self.top_limit)):
                 self.scroll_wheel_up = False
                 self.scroll_position -= (250.0 * time_delta)
                 self.scroll_position = max(self.scroll_position, self.top_limit)
@@ -297,9 +289,8 @@ class UIVerticalScrollBar(UIElement):
                 y_pos = (self.scroll_position + self.arrow_button_height)
                 self.sliding_button.set_relative_position((x_pos, y_pos))
                 moved_this_frame = True
-            elif (self.bottom_button is not None and
-                  (self.bottom_button.held or self.scroll_wheel_down) and
-                  self.scroll_position < self.bottom_limit):
+            elif ((self.bottom_button is not None and self.bottom_button.held) or
+                  (self.scroll_wheel_down and self.scroll_position < self.bottom_limit)):
                 self.scroll_wheel_down = False
                 self.scroll_position += (250.0 * time_delta)
                 self.scroll_position = min(self.scroll_position,
@@ -367,7 +358,7 @@ class UIVerticalScrollBar(UIElement):
                                                     'right': 'right',
                                                     'top': 'top',
                                                     'bottom': 'top'})
-
+            self.join_focus_sets(self.sliding_button)
         else:
             self.sliding_button.set_relative_position(self.sliding_rect_position)
             self.sliding_button.set_dimensions((self.background_rect.width, scroll_bar_height))

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -408,12 +408,12 @@ class UIManager(IUIManagerInterface):
 
             if self.focused_set is not None:
                 for item in self.focused_set:
-                    item.focus()
-
-                    if 'vertical_scroll_bar' in item.get_element_ids():
-                        self.last_focused_vertical_scrollbar = item
-                    if 'horizontal_scroll_bar' in item.get_element_ids():
-                        self.last_focused_horizontal_scrollbar = item
+                    if not item.is_focused:
+                        item.focus()
+                        if item.get_element_ids()[-1] == 'vertical_scroll_bar':
+                            self.last_focused_vertical_scrollbar = item
+                        if item.get_element_ids()[-1] == 'horizontal_scroll_bar':
+                            self.last_focused_horizontal_scrollbar = item
 
     def clear_last_focused_from_vert_scrollbar(self, vert_scrollbar: IUIElementInterface):
         """

--- a/pygame_gui/windows/ui_file_dialog.py
+++ b/pygame_gui/windows/ui_file_dialog.py
@@ -178,22 +178,24 @@ class UIFileDialog(UIWindow):
 
     def _highlight_file_name_for_editing(self):
         # try highlighting the file name
-        if self.current_file_path is not None and not self.allow_existing_files_only:
-            highlight_start = self.file_path_text_line.get_text().find(self.current_file_path.stem)
-            highlight_end = highlight_start + len(self.current_file_path.stem)
-            self.file_path_text_line.select_range[0] = highlight_start
-            self.file_path_text_line.select_range[1] = highlight_end
-            self.file_path_text_line.cursor_has_moved_recently = True
-            self.file_path_text_line.edit_position = highlight_end
+        if self.current_file_path is None or self.allow_existing_files_only:
+            return
+        highlight_start = self.file_path_text_line.get_text().find(self.current_file_path.stem)
+        highlight_end = highlight_start + len(self.current_file_path.stem)
+        self.file_path_text_line.select_range[0] = highlight_start
+        self.file_path_text_line.select_range[1] = highlight_end
+        self.file_path_text_line.cursor_has_moved_recently = True
+        self.file_path_text_line.edit_position = highlight_end
 
-            text_clip_width = (self.file_path_text_line.rect.width -
-                               (self.file_path_text_line.padding[0] * 2) -
-                               (self.file_path_text_line.shape_corner_radius * 2) -
-                               (self.file_path_text_line.border_width * 2) -
-                               (self.file_path_text_line.shadow_width * 2))
+        text_clip_width = (self.file_path_text_line.rect.width -
+                           (self.file_path_text_line.padding[0] * 2) -
+                           (self.file_path_text_line.shape_corner_radius * 2) -
+                           (self.file_path_text_line.border_width * 2) -
+                           (self.file_path_text_line.shadow_width * 2))
 
-            text_width = self.file_path_text_line.font.size(self.file_path_text_line.get_text())[0]
-            self.file_path_text_line.start_text_offset = max(0, text_width - text_clip_width)
+        text_width = self.file_path_text_line.font.size(self.file_path_text_line.get_text())[0]
+        self.file_path_text_line.start_text_offset = max(0, text_width - text_clip_width)
+        if not self.file_path_text_line.is_focused:
             self.file_path_text_line.focus()
 
     def update_current_file_list(self):

--- a/tests/test_elements/test_ui_horizontal_scroll_bar.py
+++ b/tests/test_elements/test_ui_horizontal_scroll_bar.py
@@ -134,7 +134,7 @@ class TestUIHorizontalScrollBar:
         scroll_bar = UIHorizontalScrollBar(relative_rect=pygame.Rect(100, 100, 150, 30),
                                            visible_percentage=0.7,
                                            manager=default_ui_manager)
-        scroll_bar.focus()
+        default_ui_manager.set_focus_set(scroll_bar.get_focus_set())
         assert scroll_bar.process_event(pygame.event.Event(pygame.MOUSEWHEEL, {'x': 0.5})) is True
 
         assert scroll_bar.process_event(pygame.event.Event(pygame.MOUSEWHEEL, {'x': -0.5})) is True

--- a/tests/test_elements/test_ui_text_box.py
+++ b/tests/test_elements/test_ui_text_box.py
@@ -331,8 +331,8 @@ class TestUITextBox:
                                        'alalalalal lalal alalalal al',
                              relative_rect=pygame.Rect(100, 100, 150, 100),
                              manager=default_ui_manager)
-        text_box.focus()
-        assert text_box.scroll_bar.sliding_button.is_focused is True
+        default_ui_manager.set_focus_set(text_box.get_focus_set())
+        assert text_box.scroll_bar.is_focused is True
 
     def test_set_active_effect_typing(self, _init_pygame: None, default_ui_manager: UIManager,
                                       _display_surface_return_none: None):

--- a/tests/test_elements/test_ui_vertical_scroll_bar.py
+++ b/tests/test_elements/test_ui_vertical_scroll_bar.py
@@ -134,7 +134,7 @@ class TestUIVerticalScrollBar:
         scroll_bar = UIVerticalScrollBar(relative_rect=pygame.Rect(100, 100, 30, 150),
                                          visible_percentage=0.7,
                                          manager=default_ui_manager)
-        scroll_bar.focus()
+        default_ui_manager.set_focus_set(scroll_bar.get_focus_set())
         assert scroll_bar.process_event(pygame.event.Event(pygame.MOUSEWHEEL, {'y': 0.5})) is True
 
         assert scroll_bar.process_event(pygame.event.Event(pygame.MOUSEWHEEL, {'y': -0.5})) is True


### PR DESCRIPTION
This should fix: https://github.com/MyreMylar/pygame_gui/issues/126

I forgot that the drop down menus also sometimes had scroll bars on them now somehow.

In the process of fixing this, and mainly because I'm now using pygame 2.0.0.dev10 in my main testing environment, I noticed that the scroll wheel feature wasn't working for drop down menus either. This was a simple logic failure in the update function that is now corrected.

I'm still not 100% committed to the new 'focus sets' concept but it seems to be working OK so far in it's limited domain.