### PR TITLE
Use a custom sprite group and sprite as base for gui elements

### DIFF
--- a/.github/workflows/run_tests_ci.yml
+++ b/.github/workflows/run_tests_ci.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7]
-        pygame-version: [1.9.3, 1.9.6, 2.0.0.dev10]
+        pygame-version: [1.9.4, 1.9.6, 2.0.0.dev10]
         exclude:
           - {python-version: "3.6", pygame-version: "1.9.3"}
           - {python-version: "3.7", pygame-version: "1.9.3"}

--- a/.github/workflows/run_tests_ci.yml
+++ b/.github/workflows/run_tests_ci.yml
@@ -11,8 +11,8 @@ jobs:
         python-version: [3.5, 3.6, 3.7]
         pygame-version: [1.9.4, 1.9.6, 2.0.0.dev10]
         exclude:
-          - {python-version: "3.6", pygame-version: "1.9.3"}
-          - {python-version: "3.7", pygame-version: "1.9.3"}
+          - {python-version: "3.6", pygame-version: "1.9.4"}
+          - {python-version: "3.7", pygame-version: "1.9.4"}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/run_tests_ci.yml
+++ b/.github/workflows/run_tests_ci.yml
@@ -9,10 +9,10 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7]
-        pygame-version: [1.9.4, 1.9.6, 2.0.0.dev10]
+        pygame-version: [1.9.5, 1.9.6, 2.0.0.dev10]
         exclude:
-          - {python-version: "3.6", pygame-version: "1.9.4"}
-          - {python-version: "3.7", pygame-version: "1.9.4"}
+          - {python-version: "3.6", pygame-version: "1.9.5"}
+          - {python-version: "3.7", pygame-version: "1.9.5"}
 
     steps:
     - uses: actions/checkout@v1

--- a/pygame_gui/core/layered_gui_group.py
+++ b/pygame_gui/core/layered_gui_group.py
@@ -1,0 +1,169 @@
+from pygame.sprite import LayeredUpdates, Sprite
+
+
+class GUISprite(Sprite):
+    """
+
+    """
+
+    def __init__(self, *groups):
+
+        # referred to as special_flags in the documentation of Surface.blit
+        self._blendmode = 0
+        self._visible = 1
+
+        self._image = None
+        self._rect = None
+
+        self.blit_data = [self._image, self._rect, None, self._blendmode]
+
+        # Default 0 unless initialized differently.
+        self._layer = getattr(self, '_layer', 0)
+        self.source_rect = None
+        Sprite.__init__(self, *groups)
+
+    def _set_visible(self, val):
+        """set the visible value (0 or 1) """
+        self._visible = val
+
+    def _get_visible(self):
+        """return the visible value of that sprite"""
+        return self._visible
+
+    @property
+    def visible(self):
+        """
+        You can make this sprite disappear without removing it from the group
+        assign 0 for invisible and 1 for visible
+        """
+        return self._get_visible()
+
+    @visible.setter
+    def visible(self, value):
+        self._set_visible(value)
+        for group in self.groups():
+            group.update_visibility()
+
+    @property
+    def layer(self):
+        """
+        Layer property can only be set before the sprite is added to a group,
+        after that it is read only and a sprite's layer in a group should be
+        set via the group's change_layer() method.
+
+        Overwrites dynamic property from sprite class for speed.
+        """
+        return self._layer
+
+    @layer.setter
+    def layer(self, value):
+        if not self.alive():
+            self._layer = value
+        # else:
+        #     raise AttributeError("Can't set layer directly after "
+        #                          "adding to group. Use "
+        #                          "group.change_layer(sprite, new_layer) "
+        #                          "instead.")
+
+    def __repr__(self):
+        return "<%s GUISprite(in %d groups)>" % \
+            (self.__class__.__name__, len(self.groups()))
+
+    @property
+    def image(self):
+        """
+        Layer property can only be set before the sprite is added to a group,
+        after that it is read only and a sprite's layer in a group should be
+        set via the group's change_layer() method.
+
+        Overwrites dynamic property from sprite class for speed.
+        """
+        return self._image
+
+    @image.setter
+    def image(self, value):
+        if self._image is None:
+            self._image = value
+            self.blit_data[0] = self._image
+            for group in self.groups():
+                group.update_visibility()
+        else:
+            self._image = value
+            self.blit_data[0] = self._image
+
+    @property
+    def rect(self):
+        """
+        Layer property can only be set before the sprite is added to a group,
+        after that it is read only and a sprite's layer in a group should be
+        set via the group's change_layer() method.
+
+        Overwrites dynamic property from sprite class for speed.
+        """
+        return self._rect
+
+    @rect.setter
+    def rect(self, value):
+        self._rect = value
+        self.blit_data[1] = self._rect
+
+    @property
+    def blendmode(self):
+        """
+        Layer property can only be set before the sprite is added to a group,
+        after that it is read only and a sprite's layer in a group should be
+        set via the group's change_layer() method.
+
+        Overwrites dynamic property from sprite class for speed.
+        """
+        return self._blendmode
+
+    @blendmode.setter
+    def blendmode(self, value):
+        self._blendmode = value
+        self.blit_data[3] = self._blendmode
+
+
+class LayeredGUIGroup(LayeredUpdates):
+    """
+
+    """
+    def __init__(self, *sprites):
+        """initialize group.
+
+        """
+        LayeredUpdates.__init__(self, *sprites)
+        self._clip = None
+        self.visible = []
+
+    def add_internal(self, sprite, layer=None):
+        """Do not use this method directly.
+
+        It is used by the group to add a sprite internally.
+
+        """
+        # check if all needed attributes are set
+        if not hasattr(sprite, 'visible'):
+            raise AttributeError()
+        if not hasattr(sprite, 'blendmode'):
+            raise AttributeError()
+        if not isinstance(sprite, GUISprite):
+            raise TypeError()
+
+        LayeredUpdates.add_internal(self, sprite, layer)
+        self.update_visibility()
+
+    def remove_internal(self, sprite):
+        LayeredUpdates.remove_internal(self, sprite)
+        self.update_visibility()
+
+    def draw(self, surface):
+        """draw all sprites in the right order onto the given surface
+
+        """
+        surface.blits(self.visible)
+
+    def update_visibility(self):
+        self.visible = [spr.blit_data
+                        for spr in self._spritelist
+                        if spr.image is not None and spr.visible]

--- a/pygame_gui/core/ui_container.py
+++ b/pygame_gui/core/ui_container.py
@@ -305,7 +305,6 @@ class UIContainer(UIElement, IUIContainerInterface, IContainerLikeInterface):
         """
         if not self.visible:
             self.visible = 1
-            self.dirty = 2
 
             for element in self.elements:
                 if hasattr(element, 'show'):
@@ -323,4 +322,3 @@ class UIContainer(UIElement, IUIContainerInterface, IContainerLikeInterface):
                     element.hide()
 
             self.visible = 0
-            self.dirty = 1

--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -7,9 +7,10 @@ from pygame_gui.core.interfaces import IUIElementInterface
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core.utility import render_white_text_alpha_black_bg, USE_PREMULTIPLIED_ALPHA
 from pygame_gui.core.utility import basic_blit
+from pygame_gui.core.layered_gui_group import GUISprite
 
 
-class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
+class UIElement(GUISprite, IUIElementInterface):
     """
     A base class for UI elements. You shouldn't create UI Element objects, instead all UI Element
     classes should derive from this class. Inherits from pygame.sprite.Sprite.
@@ -57,10 +58,8 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         self.image = None
 
         if visible:
-            self.dirty = 2
             self.visible = 1
         else:
-            self.dirty = 1
             self.visible = 0
 
         self.blendmode = pygame.BLEND_PREMULTIPLIED if USE_PREMULTIPLIED_ALPHA else 0
@@ -102,7 +101,6 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
             self.ui_container.add_element(self)
 
         if self.ui_container is not None and not self.ui_container.visible:
-            self.dirty = 1
             self.visible = 0
 
         self._update_absolute_rect_position_from_anchors()
@@ -806,7 +804,6 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         Shows the widget, which means the widget will get drawn and will process events.
         """
         self.visible = 1
-        self.dirty = 2
 
     def hide(self):
         """
@@ -814,7 +811,6 @@ class UIElement(pygame.sprite.DirtySprite, IUIElementInterface):
         Clear hovered state.
         """
         self.visible = 0
-        self.dirty = 1
 
         self.hovered = False
         self.hover_time = 0.0

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -13,6 +13,7 @@ from pygame_gui.core.ui_window_stack import UIWindowStack
 from pygame_gui.core.ui_container import UIContainer
 from pygame_gui.core.resource_loaders import IResourceLoader, BlockingThreadedResourceLoader
 from pygame_gui.core.utility import PackageResource
+from pygame_gui.core.layered_gui_group import LayeredGUIGroup
 
 from pygame_gui.elements import UITooltip
 
@@ -57,7 +58,7 @@ class UIManager(IUIManagerInterface):
         self.universal_empty_surface = pygame.surface.Surface((0, 0),
                                                               flags=pygame.SRCALPHA,
                                                               depth=32)
-        self.ui_group = pygame.sprite.LayeredDirty()
+        self.ui_group = LayeredGUIGroup()
 
         self.focused_set = None
         self.root_container = None

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
       zip_safe=False,
       python_requires='>=3.5',
       setup_requires=[],
-      install_requires=['pygame>=1.9.4'],
+      install_requires=['pygame>=1.9.5'],
       include_package_data=True,
       classifiers=[
           'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
       zip_safe=False,
       python_requires='>=3.5',
       setup_requires=[],
-      install_requires=['pygame>=1.9.3'],
+      install_requires=['pygame>=1.9.4'],
       include_package_data=True,
       classifiers=[
           'Development Status :: 3 - Alpha',

--- a/tests/test_core/test_ui_container.py
+++ b/tests/test_core/test_ui_container.py
@@ -173,19 +173,15 @@ class TestUIContainer:
                             _display_surface_return_none):
         container = UIContainer(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager, visible=0)
         assert container.visible == 0
-        assert container.dirty == 1
         container.show()
         assert container.visible == 1
-        assert container.dirty == 2
 
     def test_container_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                             _display_surface_return_none):
         container = UIContainer(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager, visible=1)
         assert container.visible == 1
-        assert container.dirty == 2
         container.hide()
         assert container.visible == 0
-        assert container.dirty == 1
 
     def test_container_children_inheriting_hidden_status(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                          _display_surface_return_none):
@@ -193,9 +189,7 @@ class TestUIContainer:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=container, visible=1)
         assert container.visible == 0
-        assert container.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
 
     def test_hidden_container_children_behaviour_on_show(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                          _display_surface_return_none):
@@ -203,14 +197,10 @@ class TestUIContainer:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=container)
         assert container.visible == 0
-        assert container.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
         container.show()
         assert container.visible == 1
-        assert container.dirty == 2
         assert button.visible == 1
-        assert button.dirty == 2
 
     def test_visible_container_children_behaviour_on_show(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                           _display_surface_return_none):
@@ -218,14 +208,10 @@ class TestUIContainer:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=container, visible=0)
         assert container.visible == 1
-        assert container.dirty == 2
         assert button.visible == 0
-        assert button.dirty == 1
         container.show()
         assert container.visible == 1
-        assert container.dirty == 2
         assert button.visible == 0
-        assert button.dirty == 1
 
     def test_visible_container_children_behaviour_on_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                           _display_surface_return_none):
@@ -233,14 +219,10 @@ class TestUIContainer:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=container)
         assert container.visible == 1
-        assert container.dirty == 2
         assert button.visible == 1
-        assert button.dirty == 2
         container.hide()
         assert container.visible == 0
-        assert container.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
 
     def test_hidden_container_children_behaviour_on_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                          _display_surface_return_none):
@@ -249,11 +231,7 @@ class TestUIContainer:
                           manager=default_ui_manager, container=container)
         button.show()
         assert container.visible == 0
-        assert container.dirty == 1
         assert button.visible == 1
-        assert button.dirty == 2
         container.hide()
         assert container.visible == 0
-        assert container.dirty == 1
         assert button.visible == 1
-        assert button.dirty == 2

--- a/tests/test_core/test_ui_element.py
+++ b/tests/test_core/test_ui_element.py
@@ -609,10 +609,8 @@ class TestUIElement:
                             visible=0)
 
         assert element.visible == 0
-        assert element.dirty == 1
         element.show()
         assert element.visible == 1
-        assert element.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface, _display_surface_return_none):
         element = UIElement(relative_rect=pygame.Rect(0, 0, 50, 50),
@@ -625,12 +623,10 @@ class TestUIElement:
         element.hover_time = 1.0
 
         assert element.visible == 1
-        assert element.dirty == 2
 
         element.hide()
 
         assert element.visible == 0
-        assert element.dirty == 1
 
         assert element.hovered is False
         assert element.hover_time == 0.0

--- a/tests/test_elements/test_ui_button.py
+++ b/tests/test_elements/test_ui_button.py
@@ -653,10 +653,8 @@ class TestUIButton:
                           visible=0)
 
         assert button.visible == 0
-        assert button.dirty == 1
         button.show()
         assert button.visible == 1
-        assert button.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         button = UIButton(relative_rect=pygame.Rect(100, 100, 150, 30),
@@ -664,7 +662,5 @@ class TestUIButton:
                           manager=default_ui_manager)
 
         assert button.visible == 1
-        assert button.dirty == 2
         button.hide()
         assert button.visible == 0
-        assert button.dirty == 1

--- a/tests/test_elements/test_ui_horizontal_scroll_bar.py
+++ b/tests/test_elements/test_ui_horizontal_scroll_bar.py
@@ -287,7 +287,6 @@ class TestUIHorizontalScrollBar:
                                            visible=0)
 
         assert scroll_bar.visible == 0
-        assert scroll_bar.dirty == 1
 
         assert scroll_bar.button_container.visible == 0
         assert scroll_bar.sliding_button.visible == 0
@@ -297,7 +296,6 @@ class TestUIHorizontalScrollBar:
         scroll_bar.show()
 
         assert scroll_bar.visible == 1
-        assert scroll_bar.dirty == 2
 
         assert scroll_bar.button_container.visible == 1
         assert scroll_bar.sliding_button.visible == 1
@@ -309,7 +307,6 @@ class TestUIHorizontalScrollBar:
                                            visible_percentage=0.25, manager=default_ui_manager)
 
         assert scroll_bar.visible == 1
-        assert scroll_bar.dirty == 2
 
         assert scroll_bar.button_container.visible == 1
         assert scroll_bar.sliding_button.visible == 1
@@ -319,7 +316,6 @@ class TestUIHorizontalScrollBar:
         scroll_bar.hide()
 
         assert scroll_bar.visible == 0
-        assert scroll_bar.dirty == 1
 
         assert scroll_bar.button_container.visible == 0
         assert scroll_bar.sliding_button.visible == 0

--- a/tests/test_elements/test_ui_horizontal_slider.py
+++ b/tests/test_elements/test_ui_horizontal_slider.py
@@ -329,7 +329,6 @@ class TestUIHorizontalSlider:
                                     value_range=(0, 200), manager=default_ui_manager, visible=0)
 
         assert slider.visible == 0
-        assert slider.dirty == 1
 
         assert slider.sliding_button.visible == 0
         assert slider.button_container.visible == 0
@@ -339,7 +338,6 @@ class TestUIHorizontalSlider:
         slider.show()
 
         assert slider.visible == 1
-        assert slider.dirty == 2
 
         assert slider.sliding_button.visible == 1
         assert slider.button_container.visible == 1
@@ -351,7 +349,6 @@ class TestUIHorizontalSlider:
                                     value_range=(0, 200), manager=default_ui_manager)
 
         assert slider.visible == 1
-        assert slider.dirty == 2
 
         assert slider.sliding_button.visible == 1
         assert slider.button_container.visible == 1
@@ -361,7 +358,6 @@ class TestUIHorizontalSlider:
         slider.hide()
 
         assert slider.visible == 0
-        assert slider.dirty == 1
 
         assert slider.sliding_button.visible == 0
         assert slider.button_container.visible == 0

--- a/tests/test_elements/test_ui_image.py
+++ b/tests/test_elements/test_ui_image.py
@@ -59,10 +59,8 @@ class TestUIImage:
                            visible=0)
 
         assert ui_image.visible == 0
-        assert ui_image.dirty == 1
         ui_image.show()
         assert ui_image.visible == 1
-        assert ui_image.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         loaded_image = pygame.image.load(os.path.join('tests', 'data', 'images', 'splat.png'))
@@ -71,7 +69,5 @@ class TestUIImage:
                            manager=default_ui_manager)
 
         assert ui_image.visible == 1
-        assert ui_image.dirty == 2
         ui_image.hide()
         assert ui_image.visible == 0
-        assert ui_image.dirty == 1

--- a/tests/test_elements/test_ui_label.py
+++ b/tests/test_elements/test_ui_label.py
@@ -136,10 +136,8 @@ class TestUILabel:
                         visible=0)
 
         assert label.visible == 0
-        assert label.dirty == 1
         label.show()
         assert label.visible == 1
-        assert label.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
@@ -147,7 +145,5 @@ class TestUILabel:
                         manager=default_ui_manager)
 
         assert label.visible == 1
-        assert label.dirty == 2
         label.hide()
         assert label.visible == 0
-        assert label.dirty == 1

--- a/tests/test_elements/test_ui_panel.py
+++ b/tests/test_elements/test_ui_panel.py
@@ -511,9 +511,7 @@ class TestUIPanel:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=panel, visible=1)
         assert panel.visible == 0
-        assert panel.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
 
     def test_hidden_panel_children_behaviour_on_show(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                                          _display_surface_return_none):
@@ -521,57 +519,47 @@ class TestUIPanel:
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=panel)
         assert panel.visible == 0
-        assert panel.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
         panel.show()
         assert panel.visible == 1
-        assert panel.dirty == 2
         assert button.visible == 1
-        assert button.dirty == 2
 
-    def test_visible_panel_children_behaviour_on_show(self, _init_pygame, default_ui_manager: IUIManagerInterface,
+    def test_visible_panel_children_behaviour_on_show(self, _init_pygame,
+                                                      default_ui_manager: IUIManagerInterface,
                                                           _display_surface_return_none):
-        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager, visible=1, starting_layer_height=5)
+        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager,
+                        visible=1, starting_layer_height=5)
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=panel, visible=0)
         assert panel.visible == 1
-        assert panel.dirty == 2
         assert button.visible == 0
-        assert button.dirty == 1
         panel.show()
         assert panel.visible == 1
-        assert panel.dirty == 2
         assert button.visible == 0
-        assert button.dirty == 1
 
-    def test_visible_panel_children_behaviour_on_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface,
-                                                          _display_surface_return_none):
-        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager, visible=1, starting_layer_height=5)
+    def test_visible_panel_children_behaviour_on_hide(self, _init_pygame,
+                                                      default_ui_manager: IUIManagerInterface,
+                                                      _display_surface_return_none):
+        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager,
+                        visible=1, starting_layer_height=5)
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=panel)
         assert panel.visible == 1
-        assert panel.dirty == 2
         assert button.visible == 1
-        assert button.dirty == 2
         panel.hide()
         assert panel.visible == 0
-        assert panel.dirty == 1
         assert button.visible == 0
-        assert button.dirty == 1
 
-    def test_hidden_panel_children_behaviour_on_hide(self, _init_pygame, default_ui_manager: IUIManagerInterface,
-                                                         _display_surface_return_none):
-        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager, visible=0, starting_layer_height=5)
+    def test_hidden_panel_children_behaviour_on_hide(self, _init_pygame,
+                                                     default_ui_manager: IUIManagerInterface,
+                                                     _display_surface_return_none):
+        panel = UIPanel(pygame.Rect(100, 100, 200, 200), manager=default_ui_manager,
+                        visible=0, starting_layer_height=5)
         button = UIButton(relative_rect=pygame.Rect(0, 0, 50, 50), text="",
                           manager=default_ui_manager, container=panel)
         button.show()
         assert panel.visible == 0
-        assert panel.dirty == 1
         assert button.visible == 1
-        assert button.dirty == 2
         panel.hide()
         assert panel.visible == 0
-        assert panel.dirty == 1
         assert button.visible == 1
-        assert button.dirty == 2

--- a/tests/test_elements/test_ui_screen_space_health_bar.py
+++ b/tests/test_elements/test_ui_screen_space_health_bar.py
@@ -157,10 +157,8 @@ class TestUIScreenSpaceHealthBar:
                                             visible=0)
 
         assert health_bar.visible == 0
-        assert health_bar.dirty == 1
         health_bar.show()
         assert health_bar.visible == 1
-        assert health_bar.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         healthy_sprite = HealthySprite()
@@ -169,7 +167,5 @@ class TestUIScreenSpaceHealthBar:
                                             manager=default_ui_manager)
 
         assert health_bar.visible == 1
-        assert health_bar.dirty == 2
         health_bar.hide()
         assert health_bar.visible == 0
-        assert health_bar.dirty == 1

--- a/tests/test_elements/test_ui_scrolling_container.py
+++ b/tests/test_elements/test_ui_scrolling_container.py
@@ -196,7 +196,6 @@ class TestUIScrollingContainer:
         container.set_scrollable_area_dimensions((500, 600))
 
         assert container.visible == 0
-        assert container.dirty == 1
 
         assert container._root_container.visible == 0
         assert container._view_container.visible == 0
@@ -207,7 +206,6 @@ class TestUIScrollingContainer:
         container.show()
 
         assert container.visible == 1
-        assert container.dirty == 2
 
         assert container._root_container.visible == 1
         assert container._view_container.visible == 1
@@ -222,7 +220,6 @@ class TestUIScrollingContainer:
         container.set_scrollable_area_dimensions((500, 600))
 
         assert container.visible == 1
-        assert container.dirty == 2
 
         assert container._root_container.visible == 1
         assert container._view_container.visible == 1
@@ -233,7 +230,6 @@ class TestUIScrollingContainer:
         container.hide()
 
         assert container.visible == 0
-        assert container.dirty == 1
 
         assert container._root_container.visible == 0
         assert container._view_container.visible == 0

--- a/tests/test_elements/test_ui_selection_list.py
+++ b/tests/test_elements/test_ui_selection_list.py
@@ -695,7 +695,6 @@ class TestUISelectionList:
                                          allow_multi_select=True, visible=0)
 
         assert selection_list.visible == 0
-        assert selection_list.dirty == 1
 
         assert selection_list.list_and_scroll_bar_container.visible == 0
         assert selection_list.item_list_container.visible == 0
@@ -709,7 +708,6 @@ class TestUISelectionList:
         selection_list.show()
 
         assert selection_list.visible == 1
-        assert selection_list.dirty == 2
 
         assert selection_list.list_and_scroll_bar_container.visible == 1
         assert selection_list.item_list_container.visible == 1
@@ -730,7 +728,6 @@ class TestUISelectionList:
                                          allow_multi_select=True)
 
         assert selection_list.visible == 1
-        assert selection_list.dirty == 2
 
         assert selection_list.list_and_scroll_bar_container.visible == 1
         assert selection_list.item_list_container.visible == 1
@@ -744,7 +741,6 @@ class TestUISelectionList:
         selection_list.hide()
 
         assert selection_list.visible == 0
-        assert selection_list.dirty == 1
 
         assert selection_list.list_and_scroll_bar_container.visible == 0
         assert selection_list.item_list_container.visible == 0

--- a/tests/test_elements/test_ui_text_box.py
+++ b/tests/test_elements/test_ui_text_box.py
@@ -652,14 +652,12 @@ class TestUITextBox:
                              visible=0)
 
         assert text_box.visible == 0
-        assert text_box.dirty == 1
 
         assert text_box.scroll_bar is None
 
         text_box.show()
 
         assert text_box.visible == 1
-        assert text_box.dirty == 2
 
         assert text_box.scroll_bar is None
 
@@ -681,7 +679,6 @@ class TestUITextBox:
                              visible=0)
 
         assert text_box.visible == 0
-        assert text_box.dirty == 1
 
         assert text_box.scroll_bar.visible == 0
         assert text_box.scroll_bar.button_container.visible == 0
@@ -692,7 +689,6 @@ class TestUITextBox:
         text_box.show()
 
         assert text_box.visible == 1
-        assert text_box.dirty == 2
 
         assert text_box.scroll_bar.visible == 1
         assert text_box.scroll_bar.button_container.visible == 1
@@ -717,14 +713,12 @@ class TestUITextBox:
                              object_id="screen_message")
 
         assert text_box.visible == 1
-        assert text_box.dirty == 2
 
         assert text_box.scroll_bar is None
 
         text_box.hide()
 
         assert text_box.visible == 0
-        assert text_box.dirty == 1
 
         assert text_box.scroll_bar is None
 
@@ -745,7 +739,6 @@ class TestUITextBox:
                              object_id="screen_message")
 
         assert text_box.visible == 1
-        assert text_box.dirty == 2
 
         assert text_box.scroll_bar.visible == 1
         assert text_box.scroll_bar.button_container.visible == 1
@@ -756,7 +749,6 @@ class TestUITextBox:
         text_box.hide()
 
         assert text_box.visible == 0
-        assert text_box.dirty == 1
 
         assert text_box.scroll_bar.visible == 0
         assert text_box.scroll_bar.button_container.visible == 0

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -896,17 +896,13 @@ class TestUITextEntryLine:
                                      manager=default_ui_manager, visible=0)
 
         assert text_entry.visible == 0
-        assert text_entry.dirty == 1
         text_entry.show()
         assert text_entry.visible == 1
-        assert text_entry.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager)
 
         assert text_entry.visible == 1
-        assert text_entry.dirty == 2
         text_entry.hide()
         assert text_entry.visible == 0
-        assert text_entry.dirty == 1

--- a/tests/test_elements/test_ui_vertical_scroll_bar.py
+++ b/tests/test_elements/test_ui_vertical_scroll_bar.py
@@ -287,7 +287,6 @@ class TestUIVerticalScrollBar:
                                          visible=0)
 
         assert scroll_bar.visible == 0
-        assert scroll_bar.dirty == 1
 
         assert scroll_bar.button_container.visible == 0
         assert scroll_bar.sliding_button.visible == 0
@@ -297,7 +296,6 @@ class TestUIVerticalScrollBar:
         scroll_bar.show()
 
         assert scroll_bar.visible == 1
-        assert scroll_bar.dirty == 2
 
         assert scroll_bar.button_container.visible == 1
         assert scroll_bar.sliding_button.visible == 1
@@ -309,7 +307,6 @@ class TestUIVerticalScrollBar:
                                          visible_percentage=0.25, manager=default_ui_manager)
 
         assert scroll_bar.visible == 1
-        assert scroll_bar.dirty == 2
 
         assert scroll_bar.button_container.visible == 1
         assert scroll_bar.sliding_button.visible == 1
@@ -319,7 +316,6 @@ class TestUIVerticalScrollBar:
         scroll_bar.hide()
 
         assert scroll_bar.visible == 0
-        assert scroll_bar.dirty == 1
 
         assert scroll_bar.button_container.visible == 0
         assert scroll_bar.sliding_button.visible == 0

--- a/tests/test_elements/test_ui_window.py
+++ b/tests/test_elements/test_ui_window.py
@@ -504,7 +504,6 @@ class TestUIWindow:
                           visible=0)
 
         assert window.visible == 0
-        assert window.dirty == 1
 
         assert window._window_root_container.visible == 0
         assert window.title_bar.visible == 0
@@ -514,7 +513,6 @@ class TestUIWindow:
         window.show()
 
         assert window.visible == 1
-        assert window.dirty == 2
 
         assert window._window_root_container.visible == 1
         assert window.title_bar.visible == 1
@@ -528,7 +526,6 @@ class TestUIWindow:
                           manager=default_ui_manager)
 
         assert window.visible == 1
-        assert window.dirty == 2
 
         assert window._window_root_container.visible == 1
         assert window.title_bar.visible == 1
@@ -538,7 +535,6 @@ class TestUIWindow:
         window.hide()
 
         assert window.visible == 0
-        assert window.dirty == 1
 
         assert window._window_root_container.visible == 0
         assert window.title_bar.visible == 0

--- a/tests/test_elements/test_ui_world_space_health_bar.py
+++ b/tests/test_elements/test_ui_world_space_health_bar.py
@@ -118,10 +118,8 @@ class TestUIWorldSpaceHealthBar:
                                            visible=0)
 
         assert health_bar.visible == 0
-        assert health_bar.dirty == 1
         health_bar.show()
         assert health_bar.visible == 1
-        assert health_bar.dirty == 2
 
     def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         healthy_sprite = UIWorldSpaceHealthBar.ExampleHealthSprite()
@@ -130,7 +128,5 @@ class TestUIWorldSpaceHealthBar:
                                            manager=default_ui_manager)
 
         assert health_bar.visible == 1
-        assert health_bar.dirty == 2
         health_bar.hide()
         assert health_bar.visible == 0
-        assert health_bar.dirty == 1

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -7,10 +7,10 @@ from pygame_gui.ui_manager import UIManager
 from pygame_gui.core import UIAppearanceTheme, UIWindowStack
 from pygame_gui.elements.ui_button import UIButton
 from pygame_gui.elements.ui_text_box import UITextBox
-from pygame_gui.elements.ui_vertical_scroll_bar import UIVerticalScrollBar
 from pygame_gui.windows.ui_message_window import UIMessageWindow
 from pygame_gui.elements.ui_window import UIWindow
 from pygame_gui.core.resource_loaders import IncrementalThreadedResourceLoader
+from pygame_gui.core.layered_gui_group import LayeredGUIGroup
 
 from tests.shared_fixtures import _init_pygame, default_ui_manager, _display_surface_return_none
 
@@ -45,7 +45,7 @@ class TestUIManager:
         Can we get the sprite group? Serves as a test of the sprite group being successfully created.
         """
         sprite_group = default_ui_manager.get_sprite_group()
-        assert(type(sprite_group) == pygame.sprite.LayeredDirty)
+        assert(type(sprite_group) == LayeredGUIGroup)
 
     def test_get_window_stack(self, _init_pygame, default_ui_manager):
         """

--- a/tests/test_windows/test_ui_colour_picker_dialog.py
+++ b/tests/test_windows/test_ui_colour_picker_dialog.py
@@ -159,7 +159,6 @@ class TestUIColourChannelEditor:
         channel_editor.set_dimensions((200, 29))
 
         assert channel_editor.visible == 0
-        assert channel_editor.dirty == 1
 
         assert channel_editor.element_container.visible == 0
         assert channel_editor.label.visible == 0
@@ -169,7 +168,6 @@ class TestUIColourChannelEditor:
         channel_editor.show()
 
         assert channel_editor.visible == 1
-        assert channel_editor.dirty == 2
 
         assert channel_editor.element_container.visible == 1
         assert channel_editor.label.visible == 1
@@ -191,7 +189,6 @@ class TestUIColourChannelEditor:
         channel_editor.set_dimensions((200, 29))
 
         assert channel_editor.visible == 1
-        assert channel_editor.dirty == 2
 
         assert channel_editor.element_container.visible == 1
         assert channel_editor.label.visible == 1
@@ -201,7 +198,6 @@ class TestUIColourChannelEditor:
         channel_editor.hide()
 
         assert channel_editor.visible == 0
-        assert channel_editor.dirty == 1
 
         assert channel_editor.element_container.visible == 0
         assert channel_editor.label.visible == 0
@@ -461,7 +457,6 @@ class TestUIColourPickerDialog:
                                              visible=0)
 
         assert colour_picker.visible == 0
-        assert colour_picker.dirty == 1
 
         assert colour_picker.ok_button.visible == 0
         assert colour_picker.cancel_button.visible == 0
@@ -479,7 +474,6 @@ class TestUIColourPickerDialog:
         colour_picker.show()
 
         assert colour_picker.visible == 1
-        assert colour_picker.dirty == 2
 
         assert colour_picker.ok_button.visible == 1
         assert colour_picker.cancel_button.visible == 1
@@ -501,7 +495,6 @@ class TestUIColourPickerDialog:
                                              visible=1)
 
         assert colour_picker.visible == 1
-        assert colour_picker.dirty == 2
 
         assert colour_picker.ok_button.visible == 1
         assert colour_picker.cancel_button.visible == 1
@@ -519,7 +512,6 @@ class TestUIColourPickerDialog:
         colour_picker.hide()
 
         assert colour_picker.visible == 0
-        assert colour_picker.dirty == 1
 
         assert colour_picker.ok_button.visible == 0
         assert colour_picker.cancel_button.visible == 0

--- a/tests/test_windows/test_ui_confirmation_dialog.py
+++ b/tests/test_windows/test_ui_confirmation_dialog.py
@@ -212,7 +212,6 @@ class TestUIConfirmationDialog:
                                               visible=0)
 
         assert confirm_dialog.visible == 0
-        assert confirm_dialog.dirty == 1
 
         assert confirm_dialog.confirm_button.visible == 0
         assert confirm_dialog.cancel_button.visible == 0
@@ -220,7 +219,6 @@ class TestUIConfirmationDialog:
         confirm_dialog.show()
 
         assert confirm_dialog.visible == 1
-        assert confirm_dialog.dirty == 2
 
         assert confirm_dialog.confirm_button.visible == 1
         assert confirm_dialog.cancel_button.visible == 1
@@ -235,7 +233,6 @@ class TestUIConfirmationDialog:
                                               visible=1)
 
         assert confirm_dialog.visible == 1
-        assert confirm_dialog.dirty == 2
 
         assert confirm_dialog.confirm_button.visible == 1
         assert confirm_dialog.cancel_button.visible == 1
@@ -243,12 +240,11 @@ class TestUIConfirmationDialog:
         confirm_dialog.hide()
 
         assert confirm_dialog.visible == 0
-        assert confirm_dialog.dirty == 1
 
         assert confirm_dialog.confirm_button.visible == 0
         assert confirm_dialog.cancel_button.visible == 0
 
-    def test_show_hide_rendering(self, _init_pygame, default_ui_manager, _display_surface_return_none):
+    def test_show_hide_rendering(self, _init_pygame, _display_surface_return_none):
         resolution = (500, 500)
         empty_surface = pygame.Surface(resolution)
         empty_surface.fill(pygame.Color(0, 0, 0))

--- a/tests/test_windows/test_ui_file_dialog.py
+++ b/tests/test_windows/test_ui_file_dialog.py
@@ -283,7 +283,6 @@ class TestUIUIFileDialog:
         file_dialog.file_path_text_line.set_text('tests/data/images')
 
         assert file_dialog.visible == 0
-        assert file_dialog.dirty == 1
 
         assert file_dialog.cancel_button.visible == 0
         assert file_dialog.ok_button.visible == 0
@@ -296,7 +295,6 @@ class TestUIUIFileDialog:
         file_dialog.show()
 
         assert file_dialog.visible == 1
-        assert file_dialog.dirty == 2
 
         assert file_dialog.cancel_button.visible == 1
         assert file_dialog.ok_button.visible == 1
@@ -312,7 +310,6 @@ class TestUIUIFileDialog:
         file_dialog.file_path_text_line.set_text('tests/data/images')
 
         assert file_dialog.visible == 1
-        assert file_dialog.dirty == 2
 
         assert file_dialog.cancel_button.visible == 1
         assert file_dialog.ok_button.visible == 1
@@ -325,7 +322,6 @@ class TestUIUIFileDialog:
         file_dialog.hide()
 
         assert file_dialog.visible == 0
-        assert file_dialog.dirty == 1
 
         assert file_dialog.cancel_button.visible == 0
         assert file_dialog.ok_button.visible == 0

--- a/tests/test_windows/test_ui_message_window.py
+++ b/tests/test_windows/test_ui_message_window.py
@@ -173,7 +173,6 @@ class TestUIMessageWindow:
                                          visible=0)
 
         assert message_window.visible == 0
-        assert message_window.dirty == 1
 
         assert message_window.close_window_button.visible == 0
         assert message_window.dismiss_button.visible == 0
@@ -182,7 +181,6 @@ class TestUIMessageWindow:
         message_window.show()
 
         assert message_window.visible == 1
-        assert message_window.dirty == 2
 
         assert message_window.close_window_button.visible == 1
         assert message_window.dismiss_button.visible == 1
@@ -196,7 +194,6 @@ class TestUIMessageWindow:
                                          manager=default_ui_manager)
 
         assert message_window.visible == 1
-        assert message_window.dirty == 2
 
         assert message_window.close_window_button.visible == 1
         assert message_window.dismiss_button.visible == 1
@@ -205,7 +202,6 @@ class TestUIMessageWindow:
         message_window.hide()
 
         assert message_window.visible == 0
-        assert message_window.dirty == 1
 
         assert message_window.close_window_button.visible == 0
         assert message_window.dismiss_button.visible == 0


### PR DESCRIPTION
While working on pygame I discovered a few flaws in the DirtySprite and LayeredDirtyGroup so I thought I'd just create a simpler version for the GUI that trims the draw method down to the bare minimum and makes use of properties.

From my quick testing it seems to run about 10% faster than the previous code - though it might be even better under strain as in pygame the DirtySprite technique was running at about half the speed of not using it with 5000 sprites on screen.

I need to start rounding up all the PRs into the next version I think. We'll see if this one passes all the tests and then I'll look at that tomorrow.