### PR TITLE
Ensure UITextEntryLine is not redrawn redundantly.

### DIFF
--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -434,6 +434,7 @@ class UITextEntryLine(UIElement):
             self.should_redraw = True
 
         if self.should_redraw:
+            self.should_redraw = False
             self.redraw()
 
         if self.cursor_blink_delay_after_moving_acc > self.cursor_blink_delay_after_moving:


### PR DESCRIPTION
If the cursor has moved or text has changed then we should redraw the entry line, however this variable is never reset to False, and so the element redraws on every update call.