### PR TITLE
Ensure double clicking a folder does not malform current_file_path.

### DIFF
--- a/pygame_gui/windows/ui_file_dialog.py
+++ b/pygame_gui/windows/ui_file_dialog.py
@@ -377,7 +377,8 @@ class UIFileDialog(UIWindow):
         self.file_selection_list.set_item_list(self.current_file_list)
 
         if self.current_file_path is not None and not self.allow_existing_files_only:
-            self.current_file_path = (new_directory_path / self.current_file_path.name).resolve()
+            if self.current_file_path != new_directory_path:
+                self.current_file_path = (new_directory_path / self.current_file_path.name).resolve()
             self.file_path_text_line.set_text(str(self.current_file_path))
             self._highlight_file_name_for_editing()
             self.ok_button.enable()


### PR DESCRIPTION
Currently with the UIFileDialog, double clicking a folder mangles the current_file_path (see below for gif). After pressing OK, this bad file path is returned.

![bad_gif](https://user-images.githubusercontent.com/37640160/109402419-d2eb4500-79a9-11eb-808c-292b23340605.gif)

With the proposed changes, this should be fixed, and everything else unaffected (Since we only avoid updating self.current_file_path if it is the same as new_directory_path).

After:

![good_gif](https://user-images.githubusercontent.com/37640160/109402435-ef877d00-79a9-11eb-996a-3a1b33a0a561.gif)

