### PR TITLE
definitely fix issue #185

### DIFF
--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -861,3 +861,13 @@ class UIElement(GUISprite, IUIElementInterface):
 
         self.hovered = False
         self.hover_time = 0.0
+
+    def get_appropriate_state(self):
+        """
+        Returns a string representing the appropriate state for the widgets DrawableShapes.
+        Currently only returns either 'normal' or 'disabled' based on is_enabled.
+        """
+
+        if self.is_enabled:
+            return "normal"
+        return "disabled"

--- a/pygame_gui/core/ui_element.py
+++ b/pygame_gui/core/ui_element.py
@@ -862,7 +862,7 @@ class UIElement(GUISprite, IUIElementInterface):
         self.hovered = False
         self.hover_time = 0.0
 
-    def get_appropriate_state(self):
+    def _get_appropriate_state_name(self):
         """
         Returns a string representing the appropriate state for the widgets DrawableShapes.
         Currently only returns either 'normal' or 'disabled' based on is_enabled.

--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -248,7 +248,7 @@ class UIButton(UIElement):
         Called when we leave the hover state. Resets the colours and images to normal and kills any
         tooltip that was created while we were hovering the button.
         """
-        self.drawable_shape.set_active_state(self.get_appropriate_state())
+        self.drawable_shape.set_active_state(self._get_appropriate_state_name())
         if self.tool_tip is not None:
             self.tool_tip.kill()
             self.tool_tip = None

--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -248,7 +248,7 @@ class UIButton(UIElement):
         Called when we leave the hover state. Resets the colours and images to normal and kills any
         tooltip that was created while we were hovering the button.
         """
-        self.drawable_shape.set_active_state('normal')
+        self.drawable_shape.set_active_state(self.get_appropriate_state())
         if self.tool_tip is not None:
             self.tool_tip.kill()
             self.tool_tip = None

--- a/tests/test_elements/test_ui_button.py
+++ b/tests/test_elements/test_ui_button.py
@@ -686,6 +686,16 @@ class TestUIButton:
         manager.draw_ui(surface)
         assert compare_surfaces(empty_surface, surface)
 
+    def test_hide_and_show_of_disabled_button(self, _init_pygame, _display_surface_return_none):
+        manager = UIManager((800, 600))
+        button = UIButton(relative_rect=pygame.Rect(100, 100, 100, 100), text="button test",
+                          manager=manager, starting_height=1)
+
+        button.disable()
+        button.hide()
+        button.show()
+        assert button.drawable_shape.active_state.state_id == 'disabled'
+
     def test_class_theming_id(self, _init_pygame, _display_surface_return_none):
         manager = UIManager((800, 600),
                             PackageResource('tests.data.themes',

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -3,6 +3,7 @@ import platform
 import pygame
 import pytest
 
+from pygame_gui.elements import UIDropDownMenu, UIHorizontalScrollBar
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.core import UIAppearanceTheme, UIWindowStack
 from pygame_gui.elements.ui_button import UIButton
@@ -25,6 +26,7 @@ class TestUIManager:
     """
     Testing the UIManager class
     """
+
     def test_creation(self, _init_pygame, _display_surface_return_none):
         """
         Just test whether we can create a UIManager without raising any exceptions.
@@ -36,21 +38,21 @@ class TestUIManager:
         Can we get the theme? Serves as a test of the theme being successfully created.
         """
         theme = default_ui_manager.get_theme()
-        assert(type(theme) == UIAppearanceTheme)
+        assert (type(theme) == UIAppearanceTheme)
 
     def test_get_sprite_group(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         """
         Can we get the sprite group? Serves as a test of the sprite group being successfully created.
         """
         sprite_group = default_ui_manager.get_sprite_group()
-        assert(type(sprite_group) == LayeredGUIGroup)
+        assert (type(sprite_group) == LayeredGUIGroup)
 
     def test_get_window_stack(self, _init_pygame, default_ui_manager):
         """
         Can we get the window stack? Serves as a test of the window stack being successfully created.
         """
         window_stack = default_ui_manager.get_window_stack()
-        assert(type(window_stack) == UIWindowStack)
+        assert (type(window_stack) == UIWindowStack)
 
     def test_get_shadow(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         """
@@ -208,7 +210,7 @@ class TestUIManager:
         plat = platform.system().upper()
         if plat == 'WINDOWS':
             comparison_surface = pygame.image.load(
-                os.path.join('tests', 'comparison_images', 'test_ui_manager_draw_ui.png')).convert_alpha()
+                os.path.join('comparison_images', 'test_ui_manager_draw_ui.png')).convert_alpha()
         else:
             comparison_surface = pygame.image.load(
                 os.path.join('tests', 'comparison_images', 'test_ui_manager_draw_ui_linux.png')).convert_alpha()
@@ -242,7 +244,8 @@ class TestUIManager:
         We sets the path to a font, preload it then try and use it in a text box and see if any errors or warnings
         happen.
         """
-        default_ui_manager.add_font_paths(font_name='roboto', regular_path='tests/data/Roboto-Regular.ttf')
+        default_ui_manager.add_font_paths(font_name='roboto',
+                                          regular_path=os.path.join('data', 'Roboto-Regular.ttf'))
         default_ui_manager.preload_fonts([{'name': 'roboto', 'point_size': 14, 'style': 'regular'}])
         default_ui_manager.preload_fonts([{'name': 'fira_code', 'html_size': 3, 'style': 'italic'}])
         # default_ui_manager.resource_loader.start()
@@ -290,7 +293,7 @@ class TestUIManager:
             finished, progress = incremental_loader.update()
         assert finished
 
-    def test_hover_of_hidden_elements(self,  _init_pygame, _display_surface_return_none):
+    def test_hover_of_hidden_elements(self, _init_pygame, _display_surface_return_none):
         manager = UIManager((800, 600))
         button1 = UIButton(relative_rect=pygame.Rect(100, 100, 100, 100), text="Lower button test",
                            manager=manager, starting_height=1)
@@ -312,6 +315,26 @@ class TestUIManager:
         manager.update(0.01)
         assert button1.hovered is True
         assert button2.hovered is False
+
+    def test_hide_and_show_of_disabled_elements(self, _init_pygame, _display_surface_return_none):
+        manager = UIManager((800, 600))
+        button = UIButton(relative_rect=pygame.Rect(100, 100, 100, 100), text="button test",
+                          manager=manager, starting_height=1)
+        ddmenu = UIDropDownMenu(["first", "second"], "first",
+                                relative_rect=pygame.Rect(100, 100, 100, 100), manager=manager)
+        hscroll = UIHorizontalScrollBar(relative_rect=pygame.Rect(150, 150, 150, 150),
+                                        visible_percentage=0.10, manager=manager)
+
+        elements = [
+            button,
+            ddmenu,
+            hscroll]
+
+        for e in elements:
+            e.disable()
+            e.hide()
+            e.show()
+            assert e.drawable_shape.active_state.state_id == 'disabled'
 
 
 if __name__ == '__main__':

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -316,26 +316,6 @@ class TestUIManager:
         assert button1.hovered is True
         assert button2.hovered is False
 
-    def test_hide_and_show_of_disabled_elements(self, _init_pygame, _display_surface_return_none):
-        manager = UIManager((800, 600))
-        button = UIButton(relative_rect=pygame.Rect(100, 100, 100, 100), text="button test",
-                          manager=manager, starting_height=1)
-        ddmenu = UIDropDownMenu(["first", "second"], "first",
-                                relative_rect=pygame.Rect(100, 100, 100, 100), manager=manager)
-        hscroll = UIHorizontalScrollBar(relative_rect=pygame.Rect(150, 150, 150, 150),
-                                        visible_percentage=0.10, manager=manager)
-
-        elements = [
-            button,
-            ddmenu,
-            hscroll]
-
-        for e in elements:
-            e.disable()
-            e.hide()
-            e.show()
-            assert e.drawable_shape.active_state.state_id == 'disabled'
-
 
 if __name__ == '__main__':
     pytest.console_main()

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -3,7 +3,6 @@ import platform
 import pygame
 import pytest
 
-from pygame_gui.elements import UIDropDownMenu, UIHorizontalScrollBar
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.core import UIAppearanceTheme, UIWindowStack
 from pygame_gui.elements.ui_button import UIButton
@@ -210,7 +209,7 @@ class TestUIManager:
         plat = platform.system().upper()
         if plat == 'WINDOWS':
             comparison_surface = pygame.image.load(
-                os.path.join('comparison_images', 'test_ui_manager_draw_ui.png')).convert_alpha()
+                os.path.join('tests', 'comparison_images', 'test_ui_manager_draw_ui.png')).convert_alpha()
         else:
             comparison_surface = pygame.image.load(
                 os.path.join('tests', 'comparison_images', 'test_ui_manager_draw_ui_linux.png')).convert_alpha()
@@ -245,7 +244,7 @@ class TestUIManager:
         happen.
         """
         default_ui_manager.add_font_paths(font_name='roboto',
-                                          regular_path=os.path.join('data', 'Roboto-Regular.ttf'))
+                                          regular_path=os.path.join('tests', 'data', 'Roboto-Regular.ttf'))
         default_ui_manager.preload_fonts([{'name': 'roboto', 'point_size': 14, 'style': 'regular'}])
         default_ui_manager.preload_fonts([{'name': 'fira_code', 'html_size': 3, 'style': 'italic'}])
         # default_ui_manager.resource_loader.start()


### PR DESCRIPTION
Updates UIButton.on_unhover to set normal or disabled state correctly and adds new unit test to verify correct behavior.
The unit test only fails for buttons in the old code, so it's not clear what is wrong with the other elements. I used the example suite to confirm the behavior occurs with pretty much every element.

I'd like to confirm this fix works with all elements, but I'm not entirely sure how to run the example against my branch of pygame_ui...

Oh, while I was in there I fixed a small problem with pathing on two of the tests.