### PR TITLE
Added ability to set default value(s) for UISelectionList

### DIFF
--- a/pygame_gui/elements/ui_selection_list.py
+++ b/pygame_gui/elements/ui_selection_list.py
@@ -356,6 +356,7 @@ class UISelectionList(UIElement):
             if idx is None:
                 raise ValueError(f'Requested default {d} not found in selection list {self.item_list}.')
             self.item_list[idx]['selected'] = True
+            self.item_list[idx]['button_element'].select()
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """

--- a/pygame_gui/elements/ui_selection_list.py
+++ b/pygame_gui/elements/ui_selection_list.py
@@ -332,8 +332,8 @@ class UISelectionList(UIElement):
 
         """
         default = self._default_selection
-        cmp_list = []
 
+        # Sanity check: make sure all requirements and appropriately satisfied.
         if isinstance(default, list) and self.allow_multi_select is not True:
             raise ValueError('Multiple default values specified for single-selection list.')
         elif not isinstance(default, list):
@@ -344,6 +344,8 @@ class UISelectionList(UIElement):
             if item['selected']:
                 return
 
+        # Get the index of each selection in the default selection list, then set each appropriate
+        # selected flag to true and select the button to apply theming.
         for d in default:
             if isinstance(d, str):
                 idx = next((i for i, item in enumerate(self.item_list) if item['text'] == d), None)
@@ -354,7 +356,9 @@ class UISelectionList(UIElement):
                 raise TypeError(f'Requested default {d} is not a string or (str, str) tuple.')
 
             if idx is None:
-                raise ValueError(f'Requested default {d} not found in selection list {self.item_list}.')
+                raise ValueError(
+                    f'Requested default {d} not found in selection list.')
+            
             self.item_list[idx]['selected'] = True
             self.item_list[idx]['button_element'].select()
 

--- a/pygame_gui/elements/ui_selection_list.py
+++ b/pygame_gui/elements/ui_selection_list.py
@@ -103,9 +103,10 @@ class UISelectionList(UIElement):
         self.scroll_bar_width = 20
         self.current_scroll_bar_width = 0
 
+        self.rebuild_from_changed_theme_data()
+
         if self._default_selection is not None:
             self.set_default_selection()
-        self.rebuild_from_changed_theme_data()
 
     def get_single_selection(self) -> Union[str, None]:
         """
@@ -353,7 +354,7 @@ class UISelectionList(UIElement):
                 raise TypeError(f'Requested default {d} is not a string or (str, str) tuple.')
 
             if idx is None:
-                raise ValueError(f'Requested default {d} not found in selection list.')
+                raise ValueError(f'Requested default {d} not found in selection list {self.item_list}.')
             self.item_list[idx]['selected'] = True
 
     def process_event(self, event: pygame.event.Event) -> bool:


### PR DESCRIPTION
This commit adds a default_selection arg to the UISelectionList constructor that sets the list's default state. It supports multiple defaults for multi-selection lists.

I'm not sure how relevant screenshots are since it's just a list with some items selected, but I'm more than happy to provide some if you'd like.