### PR TITLE
Have ui_manager.process_events() return consumed_event boolean

### DIFF
--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -226,7 +226,7 @@ class UIManager(IUIManagerInterface):
                             # this is not a mistake.
 
                             break
-            return consumed_event
+        return consumed_event
 
     def update(self, time_delta: float):
         """

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -195,6 +195,7 @@ class UIManager(IUIManagerInterface):
         windows from receiving input.
 
         :param event:  pygame.event.Event - the event to process.
+        :return: A boolean indicating whether the event was consumed.
         """
         consumed_event = False
         sorting_consumed_event = False
@@ -225,6 +226,7 @@ class UIManager(IUIManagerInterface):
                             # this is not a mistake.
 
                             break
+            return consumed_event
 
     def update(self, time_delta: float):
         """


### PR DESCRIPTION
Found that when a dropdown menu covers a portion of the game that handles mouse events, the game will handle mouse events intended for the drop down menu and already consumed by ui_manager, causing unexpected behaviors.

Returning the consumed_event boolean allows the game logic to skip consumed events.

Updated doc string and verified that docs build.

Resolves #238.