### PR TITLE
New UIStatusBar class

### DIFF
--- a/docs/source/pygame_gui.elements.rst
+++ b/docs/source/pygame_gui.elements.rst
@@ -68,6 +68,14 @@ pygame\_gui.elements.ui\_selection\_list module
    :no-undoc-members:
    :show-inheritance:
 
+pygame\_gui.elements.ui\_status\_bar module
+----------------------------------------------------------
+
+.. automodule:: pygame_gui.elements.ui_status_bar
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 pygame\_gui.elements.ui\_text\_box module
 -----------------------------------------
 

--- a/docs/source/theme_guide.rst
+++ b/docs/source/theme_guide.rst
@@ -315,6 +315,7 @@ Theme Options Per Element
     theme_reference/theme_screen_space_health_bar
     theme_reference/theme_scrolling_container
     theme_reference/theme_selection_list
+    theme_reference/theme_status_bar
     theme_reference/theme_text_box
     theme_reference/theme_text_entry_line
     theme_reference/theme_tooltip

--- a/docs/source/theme_reference/theme_status_bar.rst
+++ b/docs/source/theme_reference/theme_status_bar.rst
@@ -1,0 +1,56 @@
+.. _status-bar:
+
+UIStatusBar Theming Parameters
+=========================================
+
+The :class:`UIStatusBar <pygame_gui.elements.UIStatusBar>` theming block id is 'status_bar'.
+
+Colours
+-------
+
+.. figure:: ../_static/world_space_health_bar_colour_parameters.png
+
+   A diagram of which part of the element is themed by which colour parameter.
+
+:class:`UIStatusBar <pygame_gui.elements.UIStatusBar>` makes use of these colour parameters in a 'colours' block:
+
+ - "**normal_border**" - The colour/gradient of the health bar's border if it has one.
+ - "**filled_bar**" - The colour/gradient of the actual bar itself, of the portion of it that is still full.
+ - "**unfilled_bar**" - The colour/gradient of an empty portion of the health bar.
+
+Misc
+-----
+
+:class:`UIStatusBar <pygame_gui.elements.UIStatusBar>` has the following miscellaneous parameters in a 'misc' block:
+
+ - "**shape**" - Can be one of 'rectangle' or 'rounded_rectangle'. Different shapes for this UI element.
+ - "**shape_corner_radius**" - Only used if our shape is 'rounded_rectangle'. It sets the radius used for the rounded corners.
+ - "**hover_height**" - The height in pixels that the health bar will appear over the sprite. Defaults to "10".
+ - "**border_width**" - The width of the border around the health bar. Defaults to "1". Can be "0" to remove the border.
+ - "**shadow_width**" - The width of the border around the health bar. Defaults to "1". Can be "0" to remove the border.
+
+Example
+-------
+
+Here is an example of a status bar block in a JSON theme file using the parameters described above.
+
+.. code-block:: json
+   :caption: status_bar.json
+   :linenos:
+
+    {
+        "status_bar":
+        {
+            "colours":
+            {
+                "normal_border": "#AAAAAA",
+                "filled_bar": "#f4251b",
+                "unfilled_bar": "#CCCCCC"
+            },
+            "misc":
+            {
+                "hover_height": "5",
+                "border_width": "0"
+            }
+        }
+    }

--- a/pygame_gui/elements/__init__.py
+++ b/pygame_gui/elements/__init__.py
@@ -12,6 +12,7 @@ from pygame_gui.elements.ui_text_box import UITextBox
 from pygame_gui.elements.ui_text_entry_line import UITextEntryLine
 from pygame_gui.elements.ui_tool_tip import UITooltip
 from pygame_gui.elements.ui_drop_down_menu import UIDropDownMenu
+from pygame_gui.elements.ui_status_bar import UIStatusBar
 from pygame_gui.elements.ui_world_space_health_bar import UIWorldSpaceHealthBar
 from pygame_gui.elements.ui_window import UIWindow
 from pygame_gui.elements.ui_scrolling_container import UIScrollingContainer

--- a/pygame_gui/elements/ui_status_bar.py
+++ b/pygame_gui/elements/ui_status_bar.py
@@ -1,0 +1,228 @@
+from typing import Union, Dict, Callable
+
+import pygame
+
+from pygame_gui.core import ObjectID
+from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
+from pygame_gui.core import UIElement
+from pygame_gui.core.drawable_shapes import RectDrawableShape, RoundedRectangleShape
+
+
+class UIStatusBar(UIElement):
+    """
+    Displays a status/progress bar.
+
+    This is a flexible class that can be used to display status for a sprite (health/mana/fatigue, etc),
+    or to provide a status bar on the screen not attached to any particular object. You can use multiple
+    status bars for a sprite to show different status items if desired.
+
+    You can use the percent_full attribute to manually set the status, or you can provide a pointer to a method
+    that will provide the percentage information.
+
+    :param relative_rect: The rectangle that defines the size of the health bar.
+    :param display_sprite: Optional sprite to attach the bar to.
+    :param percent_method: Optional method signature to call to get the percent complete. (To provide a method signature,
+                           simply reference the method without parenthesis, such as self.health_percent.)
+    :param manager: The UIManager that manages this element.
+    :param container: The container that this element is within. If set to None will be the root window's container.
+    :param parent_element: The element this element 'belongs to' in the theming hierarchy.
+    :param object_id: A custom defined ID for fine tuning of theming.
+    :param anchors: A dictionary describing what this element's relative_rect is relative to.
+    :param visible: Whether the element is visible by default. Warning - container visibility
+                    may override this.
+
+    """
+
+    element_id = 'status_bar'
+
+    def __init__(self,
+                 relative_rect: pygame.Rect,
+                 manager: IUIManagerInterface,
+                 display_sprite: Union[pygame.sprite.Sprite, None] = None,
+                 percent_method: Union[Callable[[], float], None] = None,
+                 container: Union[IContainerLikeInterface, None] = None,
+                 parent_element: UIElement = None,
+                 object_id: Union[ObjectID, str, None] = None,
+                 anchors: Dict[str, str] = None,
+                 visible: int = 1):
+
+        super().__init__(relative_rect, manager, container,
+                         starting_height=1,
+                         layer_thickness=1,
+                         anchors=anchors,
+                         visible=visible)
+
+        self.display_sprite = display_sprite
+        self.percent_method = percent_method
+
+        self._create_valid_ids(container=container,
+                               parent_element=parent_element,
+                               object_id=object_id,
+                               element_id=self.element_id)
+
+        self._percent_full = 0
+        self.status_changed = False
+
+        self.border_colour = None
+        self.health_empty_colour = None
+        self.bar_filled_colour = None
+        self.bar_unfilled_colour = None
+        self.health_colour = None
+        self.hover_height = None
+        self.border_width = None
+        self.shadow_width = None
+        self.position = None
+        self.border_rect = None
+        self.capacity_width = None
+        self.capacity_height = None
+        self.capacity_rect = None
+        self.current_status_rect = None
+
+        self.drawable_shape = None
+        self.shape = 'rectangle'
+        self.shape_corner_radius = None
+
+        self.set_image(None)
+
+        self.rebuild_from_changed_theme_data()
+
+    @property
+    def percent_full(self):
+        return self._percent_full
+
+    @percent_full.setter
+    def percent_full(self, value):
+        # We need a decimal percentage
+        if value > 1:
+            value = value / 100
+        if value != self._percent_full:
+            self._percent_full = value
+            self.status_changed = True
+
+    def rebuild(self):
+        """
+        Rebuild the health bar entirely because the theming data has changed.
+
+        """
+
+        if self.display_sprite:
+            self.position = [self.display_sprite.rect.x,
+                             self.display_sprite.rect.y - self.hover_height]
+        else:
+            self.position = [self.relative_rect.x,
+                             self.relative_rect.y]
+
+        self.rect.x = self.position[0]
+        self.rect.y = self.position[1]
+
+        self.border_rect = pygame.Rect((self.shadow_width, self.shadow_width),
+                                       (self.rect.width - (self.shadow_width * 2),
+                                        self.rect.height - (self.shadow_width * 2)))
+
+        self.capacity_width = self.rect.width - (self.shadow_width * 2) - (self.border_width * 2)
+        self.capacity_height = self.rect.height - (self.shadow_width * 2) - (self.border_width * 2)
+        self.capacity_rect = pygame.Rect((self.border_width + self.shadow_width,
+                                          self.border_width + self.shadow_width),
+                                         (self.capacity_width, self.capacity_height))
+
+        self.redraw()
+
+    def update(self, time_delta: float):
+        """
+        Updates the health bar sprite's image and rectangle with the latest health and position
+        data from the sprite we are monitoring
+
+        :param time_delta: time passed in seconds between one call to this method and the next.
+
+        """
+        super().update(time_delta)
+        if self.alive():
+            if self.display_sprite:
+                self.position = [self.display_sprite.rect.x,
+                                 self.display_sprite.rect.y - self.hover_height]
+            else:
+                self.position = [self.relative_rect.x,
+                                 self.relative_rect.y]
+
+            self.rect.x = self.position[0]
+            self.rect.y = self.position[1]
+            self.relative_rect.topleft = self.rect.topleft
+
+            # If they've provided a method to call, we'll track previous value in percent_full.
+            if self.percent_method:
+                current_percent = self.percent_method()
+                if current_percent != self.percent_full:
+                    # This triggers status_changed.
+                    self.percent_full = current_percent
+
+            if self.status_changed:
+                self.status_changed = False
+                self.redraw()
+
+    def redraw(self):
+        """
+        Redraw the health bar when something, other than it's position has changed.
+        """
+        theming_parameters = {'normal_bg': self.bar_unfilled_colour,
+                              'normal_border': self.border_colour,
+                              'border_width': self.border_width,
+                              'shadow_width': self.shadow_width,
+                              'shape_corner_radius': self.shape_corner_radius,
+                              'filled_bar': self.bar_filled_colour,
+                              'filled_bar_width_percentage': self.percent_full}
+
+        if self.shape == 'rectangle':
+            self.drawable_shape = RectDrawableShape(self.rect, theming_parameters,
+                                                    ['normal'], self.ui_manager)
+        elif self.shape == 'rounded_rectangle':
+            self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
+                                                        ['normal'], self.ui_manager)
+
+        self.set_image(self.drawable_shape.get_fresh_surface())
+
+    def rebuild_from_changed_theme_data(self):
+        """
+        Called by the UIManager to check the theming data and rebuild whatever needs rebuilding
+        for this element when the theme data has changed.
+        """
+        super().rebuild_from_changed_theme_data()
+
+        has_any_changed = False
+
+        if self._check_misc_theme_data_changed(attribute_name='shape',
+                                               default_value='rectangle',
+                                               casting_func=str,
+                                               allowed_values=['rectangle',
+                                                               'rounded_rectangle']):
+            has_any_changed = True
+
+        if self._check_shape_theming_changed(defaults={'border_width': 1,
+                                                       'shadow_width': 2,
+                                                       'shape_corner_radius': 2}):
+            has_any_changed = True
+
+        if self._check_misc_theme_data_changed(attribute_name='hover_height',
+                                               default_value=1,
+                                               casting_func=int):
+            has_any_changed = True
+
+        border_colour = self.ui_theme.get_colour_or_gradient('normal_border',
+                                                             self.combined_element_ids)
+        if border_colour != self.border_colour:
+            self.border_colour = border_colour
+            has_any_changed = True
+
+        bar_unfilled_colour = self.ui_theme.get_colour_or_gradient('unfilled_bar',
+                                                                   self.combined_element_ids)
+        if bar_unfilled_colour != self.bar_unfilled_colour:
+            self.bar_unfilled_colour = bar_unfilled_colour
+            has_any_changed = True
+
+        bar_filled_colour = self.ui_theme.get_colour_or_gradient('filled_bar',
+                                                                 self.combined_element_ids)
+        if bar_filled_colour != self.bar_filled_colour:
+            self.bar_filled_colour = bar_filled_colour
+            has_any_changed = True
+
+        if has_any_changed:
+            self.rebuild()

--- a/pygame_gui/elements/ui_world_space_health_bar.py
+++ b/pygame_gui/elements/ui_world_space_health_bar.py
@@ -5,10 +5,10 @@ import pygame
 from pygame_gui.core import ObjectID
 from pygame_gui.core.interfaces import IContainerLikeInterface, IUIManagerInterface
 from pygame_gui.core import UIElement
-from pygame_gui.core.drawable_shapes import RectDrawableShape, RoundedRectangleShape
+from pygame_gui.elements.ui_status_bar import UIStatusBar
 
 
-class UIWorldSpaceHealthBar(UIElement):
+class UIWorldSpaceHealthBar(UIStatusBar):
     """
     A UI that will display a sprite's 'health_capacity' and their 'current_health' in 'world space'
     above the sprite. This means that the health bar will move with the camera and the sprite
@@ -41,6 +41,8 @@ class UIWorldSpaceHealthBar(UIElement):
             self.health_capacity = 100
             self.rect = pygame.Rect(0, 0, 32, 64)
 
+    element_id = 'world_space_health_bar'
+
     def __init__(self,
                  relative_rect: pygame.Rect,
                  sprite_to_monitor: Union[pygame.sprite.Sprite, ExampleHealthSprite],
@@ -51,17 +53,6 @@ class UIWorldSpaceHealthBar(UIElement):
                  anchors: Dict[str, str] = None,
                  visible: int = 1):
 
-        super().__init__(relative_rect, manager, container,
-                         starting_height=1,
-                         layer_thickness=1,
-                         anchors=anchors,
-                         visible=visible)
-
-        self._create_valid_ids(container=container,
-                               parent_element=parent_element,
-                               object_id=object_id,
-                               element_id='world_space_health_bar')
-
         if sprite_to_monitor is not None:
             if not hasattr(sprite_to_monitor, 'health_capacity'):
                 raise AttributeError('Sprite does not have health_capacity attribute')
@@ -70,156 +61,26 @@ class UIWorldSpaceHealthBar(UIElement):
             self.sprite_to_monitor = sprite_to_monitor
         else:
             self.sprite_to_monitor = None
-            raise AssertionError('Need sprite to monitor')
+            if self.__class__ == UIWorldSpaceHealthBar:
+                raise AssertionError('Need sprite to monitor')
 
-        self.current_health = self.sprite_to_monitor.current_health
-        self.health_capacity = self.sprite_to_monitor.health_capacity
-        self.health_percentage = self.current_health / self.health_capacity
+        super().__init__(relative_rect=relative_rect,
+                         manager=manager,
+                         display_sprite=sprite_to_monitor,
+                         percent_method=self.health_percent,
+                         container=container,
+                         parent_element=parent_element,
+                         object_id=object_id,
+                         anchors=anchors,
+                         visible=visible)
 
-        self.border_colour = None
-        self.health_empty_colour = None
-        self.bar_filled_colour = None
-        self.bar_unfilled_colour = None
-        self.health_colour = None
-        self.hover_height = None
-        self.border_width = None
-        self.shadow_width = None
-        self.position = None
-        self.border_rect = None
-        self.capacity_width = None
-        self.capacity_height = None
-        self.health_capacity_rect = None
-        self.current_health_rect = None
+    @property
+    def current_health(self):
+        return self.sprite_to_monitor.current_health
 
-        self.drawable_shape = None
-        self.shape = 'rectangle'
-        self.shape_corner_radius = None
+    @property
+    def health_capacity(self):
+        return self.sprite_to_monitor.health_capacity
 
-        self.set_image(None)
-
-        self.rebuild_from_changed_theme_data()
-
-    def rebuild(self):
-        """
-        Rebuild the health bar entirely because the theming data has changed.
-
-        """
-
-        self.position = [self.sprite_to_monitor.rect.x,
-                         self.sprite_to_monitor.rect.y - self.hover_height]
-
-        self.rect.x = self.position[0]
-        self.rect.y = self.position[1]
-
-        self.border_rect = pygame.Rect((self.shadow_width, self.shadow_width),
-                                       (self.rect.width - (self.shadow_width * 2),
-                                        self.rect.height - (self.shadow_width * 2)))
-
-        self.capacity_width = self.rect.width - (self.shadow_width * 2) - (self.border_width * 2)
-        self.capacity_height = self.rect.height - (self.shadow_width * 2) - (self.border_width * 2)
-        self.health_capacity_rect = pygame.Rect((self.border_width + self.shadow_width,
-                                                 self.border_width + self.shadow_width),
-                                                (self.capacity_width, self.capacity_height))
-
-        self.current_health_rect = pygame.Rect((self.border_width + self.shadow_width,
-                                                self.border_width + self.shadow_width),
-                                               (int(self.capacity_width * self.health_percentage),
-                                                self.capacity_height))
-
-        self.redraw()
-
-    def update(self, time_delta: float):
-        """
-        Updates the health bar sprite's image and rectangle with the latest health and position
-        data from the sprite we are monitoring
-
-        :param time_delta: time passed in seconds between one call to this method and the next.
-
-        """
-        super().update(time_delta)
-        if self.alive():
-            self.position = [self.sprite_to_monitor.rect.x,
-                             self.sprite_to_monitor.rect.y - self.hover_height]
-
-            self.rect.x = self.position[0]
-            self.rect.y = self.position[1]
-            self.relative_rect.topleft = self.rect.topleft
-
-            if (self.current_health != self.sprite_to_monitor.current_health) or (
-                    self.health_capacity != self.sprite_to_monitor.health_capacity):
-
-                self.current_health = self.sprite_to_monitor.current_health
-                self.health_capacity = self.sprite_to_monitor.health_capacity
-                self.health_percentage = self.current_health / self.health_capacity
-
-                self.redraw()
-
-    def redraw(self):
-        """
-        Redraw the health bar when something, other than it's position has changed.
-        """
-        self.current_health_rect.width = int(self.capacity_width * self.health_percentage)
-
-        theming_parameters = {'normal_bg': self.bar_unfilled_colour,
-                              'normal_border': self.border_colour,
-                              'border_width': self.border_width,
-                              'shadow_width': self.shadow_width,
-                              'shape_corner_radius': self.shape_corner_radius,
-                              'filled_bar': self.bar_filled_colour,
-                              'filled_bar_width_percentage': self.health_percentage}
-
-        if self.shape == 'rectangle':
-            self.drawable_shape = RectDrawableShape(self.rect, theming_parameters,
-                                                    ['normal'], self.ui_manager)
-        elif self.shape == 'rounded_rectangle':
-            self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
-                                                        ['normal'], self.ui_manager)
-
-        self.set_image(self.drawable_shape.get_fresh_surface())
-
-    def rebuild_from_changed_theme_data(self):
-        """
-        Called by the UIManager to check the theming data and rebuild whatever needs rebuilding
-        for this element when the theme data has changed.
-        """
-        super().rebuild_from_changed_theme_data()
-
-        has_any_changed = False
-
-        if self._check_misc_theme_data_changed(attribute_name='shape',
-                                               default_value='rectangle',
-                                               casting_func=str,
-                                               allowed_values=['rectangle',
-                                                               'rounded_rectangle']):
-            has_any_changed = True
-
-        if self._check_shape_theming_changed(defaults={'border_width': 1,
-                                                       'shadow_width': 2,
-                                                       'shape_corner_radius': 2}):
-            has_any_changed = True
-
-        if self._check_misc_theme_data_changed(attribute_name='hover_height',
-                                               default_value=1,
-                                               casting_func=int):
-            has_any_changed = True
-
-        border_colour = self.ui_theme.get_colour_or_gradient('normal_border',
-                                                             self.combined_element_ids)
-        if border_colour != self.border_colour:
-            self.border_colour = border_colour
-            has_any_changed = True
-
-        bar_unfilled_colour = self.ui_theme.get_colour_or_gradient('unfilled_bar',
-                                                                   self.combined_element_ids)
-        if bar_unfilled_colour != self.bar_unfilled_colour:
-            self.bar_unfilled_colour = bar_unfilled_colour
-            has_any_changed = True
-
-        bar_filled_colour = self.ui_theme.get_colour_or_gradient('filled_bar',
-                                                                 self.combined_element_ids)
-        if bar_filled_colour != self.bar_filled_colour:
-            self.bar_filled_colour = bar_filled_colour
-            has_any_changed = True
-
-        if has_any_changed:
-            self.rebuild()
+    def health_percent(self):
+        return self.current_health / self.health_capacity

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -226,7 +226,7 @@ class UIManager(IUIManagerInterface):
                             # this is not a mistake.
 
                             break
-            return consumed_event
+        return consumed_event
 
     def update(self, time_delta: float):
         """

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -195,6 +195,7 @@ class UIManager(IUIManagerInterface):
         windows from receiving input.
 
         :param event:  pygame.event.Event - the event to process.
+        :return: A boolean indicating whether the event was consumed.
         """
         consumed_event = False
         sorting_consumed_event = False
@@ -225,6 +226,7 @@ class UIManager(IUIManagerInterface):
                             # this is not a mistake.
 
                             break
+            return consumed_event
 
     def update(self, time_delta: float):
         """

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -351,15 +351,15 @@ class UIManager(IUIManagerInterface):
         'fira_code' font) you must first add the paths to the files for those fonts, then load the
         specific fonts with a list of font descriptions in a dictionary form like so:
 
-        code:`{'name': 'fira_code', 'point_size': 12, 'style': 'bold_italic'}`
+            ``{'name': 'fira_code', 'point_size': 12, 'style': 'bold_italic'}``
 
         You can specify size either in pygame.Font point sizes with 'point_size', or in HTML style
         sizes with 'html_size'. Style options are:
 
-        - 'regular'
-        - 'italic'
-        - 'bold'
-        - 'bold_italic'
+        - ``'regular'``
+        - ``'italic'``
+        - ``'bold'``
+        - ``'bold_italic'``
 
         The name parameter here must match the one you used when you added the file paths.
 
@@ -484,7 +484,7 @@ class UIManager(IUIManagerInterface):
 
         The expected input is in the same format as the standard pygame cursor module, except
         without expanding the initial Tuple. So, to call this function with the default pygame
-        arrow cursor you would do:
+        arrow cursor you would do::
 
             manager.set_active_cursor(pygame.SYSTEM_CURSOR_ARROW)
 

--- a/tests/data/themes/ui_status_bar_bad_values.json
+++ b/tests/data/themes/ui_status_bar_bad_values.json
@@ -1,0 +1,19 @@
+{
+    "status_bar":
+    {
+        "colours":
+         {
+             "normal_border": "black",
+             "filled_bar": "#f4251b,#FF0000AA,90",
+             "unfilled_bar": "slipper"
+         },
+         "misc":
+         {
+             "shape": "rounded_wrecktangle",
+             "shape_corner_radius": "6.0",
+             "hover_height": "5.0",
+             "border_width": "flip",
+             "shadow_width": "flop"
+         }
+    }
+}

--- a/tests/data/themes/ui_status_bar_no_default.json
+++ b/tests/data/themes/ui_status_bar_no_default.json
@@ -1,0 +1,19 @@
+{
+    "status_bar":
+    {
+        "colours":
+         {
+             "normal_border": "#AAAAAA,#FFFFFF,0",
+             "filled_bar": "#f4251b,#FF0000AA,90",
+             "unfilled_bar": "#CCCCCF"
+         },
+         "misc":
+         {
+             "shape": "rounded_rectangle",
+             "shape_corner_radius": "6",
+             "hover_height": "5",
+             "border_width": "0",
+             "shadow_width": "3"
+         }
+    }
+}

--- a/tests/test_elements/test_ui_status_bar.py
+++ b/tests/test_elements/test_ui_status_bar.py
@@ -1,0 +1,142 @@
+import os
+import pytest
+import pygame
+
+from tests.shared_comparators import compare_surfaces
+
+from pygame_gui.ui_manager import UIManager
+from pygame_gui.elements.ui_status_bar import UIStatusBar
+
+
+class HealthySprite(pygame.sprite.Sprite):
+    def __init__(self, *groups):
+        super().__init__(*groups)
+        self.current_health = 50
+        self.health_capacity = 100
+        self.rect = pygame.Rect(0, 0, 32, 64)
+
+    def health_percent(self):
+        return self.current_health / self.health_capacity
+
+
+class TestUIStatusBar:
+
+    def test_creation(self, _init_pygame, default_ui_manager):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+        assert health_bar.image is not None
+
+    def test_update(self, _init_pygame, default_ui_manager):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+        healthy_sprite.current_health = 10
+        health_bar.update(0.01)
+        assert health_bar.image is not None
+
+    def test_rebuild_from_theme_data_non_default(self, _init_pygame):
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_status_bar_no_default.json"))
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=manager)
+        assert health_bar.image is not None
+
+    @pytest.mark.filterwarnings("ignore:Invalid value")
+    @pytest.mark.filterwarnings("ignore:Colour hex code")
+    def test_rebuild_from_theme_data_bad_values(self, _init_pygame):
+        manager = UIManager((800, 600), os.path.join("tests", "data", "themes", "ui_status_bar_bad_values.json"))
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=manager)
+        assert health_bar.image is not None
+
+    def test_set_position(self, _init_pygame, default_ui_manager):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+
+        health_bar.set_position((150.0, 30.0))
+
+        assert health_bar.rect.topleft == (150, 30)
+
+    def test_set_relative_position(self, _init_pygame, default_ui_manager):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+
+        health_bar.set_relative_position((150.0, 30.0))
+
+        assert health_bar.rect.topleft == (150, 30)
+
+    def test_set_dimensions(self, _init_pygame, default_ui_manager):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+
+        health_bar.set_dimensions((250.0, 60.0))
+
+        assert health_bar.drawable_shape.containing_rect.size == (250, 60)
+        assert health_bar.rect.size == (250, 60)
+        assert health_bar.relative_rect.size == (250, 60)
+
+    def test_show(self, _init_pygame, default_ui_manager, _display_surface_return_none):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager,
+                                 visible=0)
+
+        assert health_bar.visible == 0
+        health_bar.show()
+        assert health_bar.visible == 1
+
+    def test_hide(self, _init_pygame, default_ui_manager, _display_surface_return_none):
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                 display_sprite=healthy_sprite,
+                                 manager=default_ui_manager)
+
+        assert health_bar.visible == 1
+        health_bar.hide()
+        assert health_bar.visible == 0
+
+    def test_show_hide_rendering(self, _init_pygame, default_ui_manager, _display_surface_return_none):
+        resolution = (400, 400)
+        empty_surface = pygame.Surface(resolution)
+        empty_surface.fill(pygame.Color(0, 0, 0))
+
+        surface = empty_surface.copy()
+        manager = UIManager(resolution)
+
+        healthy_sprite = HealthySprite()
+        health_bar = UIStatusBar(relative_rect=pygame.Rect(100, 100, 400, 400),
+                                 display_sprite=healthy_sprite,
+                                 manager=manager,
+                                 visible=0)
+        manager.update(0.01)
+        manager.draw_ui(surface)
+        assert compare_surfaces(empty_surface, surface)
+
+        surface.fill(pygame.Color(0, 0, 0))
+        health_bar.show()
+        manager.update(0.01)
+        manager.draw_ui(surface)
+        assert not compare_surfaces(empty_surface, surface)
+
+        surface.fill(pygame.Color(0, 0, 0))
+        health_bar.hide()
+        manager.update(0.01)
+        manager.draw_ui(surface)
+        assert compare_surfaces(empty_surface, surface)
+
+
+if __name__ == '__main__':
+    pytest.console_main()


### PR DESCRIPTION
UIStatusBar is designed to be a flexible class for any kind of status/progress bar. It can be placed directly on the screen, or tied to a sprite. Multiple status bars can be associated with a sprite. The progress bar status can be set directly, or via a specified method signature.

Refactored UIWorldSpaceHealthBar to be a subclass of this (failed to do the same for UIScreenSpaceHealthBar so left it alone).

If this is accepted, recommend phasing out UIProgressBar, which provides no unique functionality.

Also, unlike UIProgressBar, provided a full set of tests, docs, and theme docs...:)