### PR TITLE
Deprecate set_image() for everything except UIImage

### DIFF
--- a/pygame_gui/core/interfaces/element_interface.py
+++ b/pygame_gui/core/interfaces/element_interface.py
@@ -220,7 +220,7 @@ class IUIElementInterface(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def set_image_clip(self, rect: Union[pygame.Rect, None]):
+    def _set_image_clip(self, rect: Union[pygame.Rect, None]):
         """
         Sets a clipping rectangle on this element's image determining what portion of it will
         actually be displayed when this element is blitted to the screen.
@@ -240,6 +240,17 @@ class IUIElementInterface(metaclass=ABCMeta):
 
     @abstractmethod
     def set_image(self, new_image: Union[pygame.surface.Surface, None]):
+        """
+        Deprecated for most elements - to avoid confusion with setting the image for the UIImage element.
+
+        Generally the average user shouldn't be directly setting what this was setting.
+
+        :param new_image: The new image to set.
+
+        """
+
+    @abstractmethod
+    def _set_image(self, new_image: Union[pygame.surface.Surface, None]):
         """
         Wraps setting the image variable of this element so that we also set the current image
         clip on the image at the same time.

--- a/pygame_gui/core/ui_container.py
+++ b/pygame_gui/core/ui_container.py
@@ -57,7 +57,7 @@ class UIContainer(UIElement, IUIContainerInterface, IContainerLikeInterface):
                                element_id='container')
 
         self.sprite_group = self.ui_manager.get_sprite_group()
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
 
         self.max_element_top_layer = 0  # default to top layer 0
         self.layer_thickness = 0  # default to 0 thickness for an empty container

--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -96,7 +96,7 @@ class UIButton(UIElement):
         self.text_surface = None
         self.aligned_text_rect = None
 
-        self.set_image(None)
+        self._set_image(None)
 
         # default range at which we 'let go' of a button
         self.hold_range = (0, 0)

--- a/pygame_gui/elements/ui_drop_down_menu.py
+++ b/pygame_gui/elements/ui_drop_down_menu.py
@@ -96,7 +96,7 @@ class UIExpandedDropDownState:
                                                                           ['normal'],
                                                                           self.ui_manager)
 
-        self.on_fresh_drawable_shape_ready()
+        self.drop_down_menu_ui.on_fresh_drawable_shape_ready()
 
         # extra
         if self.close_button is not None:
@@ -342,15 +342,6 @@ class UIExpandedDropDownState:
                                               self.base_position_rect.height))
             self.close_button.set_relative_position((close_button_x, border_and_shadow))
 
-    def on_fresh_drawable_shape_ready(self):
-        """
-        Called by an element's drawable shape when it has a new image surface ready for use,
-        normally after a rebuilding/redrawing of some kind.
-
-        In this case the result is to set the UI element's image to the new surface.
-        """
-        self.drop_down_menu_ui.set_image(self.drop_down_menu_ui.drawable_shape.get_fresh_surface())
-
     def hide(self):
         """
         Transition from expanded state to closed state.
@@ -450,7 +441,7 @@ class UIClosedDropDownState:
                                                                           ['normal', 'disabled'],
                                                                           self.ui_manager)
 
-        self.drop_down_menu_ui.set_image(self.drop_down_menu_ui.drawable_shape.get_fresh_surface())
+        self.drop_down_menu_ui._set_image(self.drop_down_menu_ui.drawable_shape.get_fresh_surface())
 
         # extra
         if self.open_button is not None:
@@ -584,15 +575,6 @@ class UIClosedDropDownState:
             self.open_button.set_dimensions((self.open_button_width,
                                              self.base_position_rect.height))
             self.open_button.set_relative_position((open_button_x, border_and_shadow))
-
-    def on_fresh_drawable_shape_ready(self):
-        """
-        Called by an element's drawable shape when it has a new image surface ready for use,
-        normally after a rebuilding/redrawing of some kind.
-
-        In this case the result is to set the UI element's image to the new surface.
-        """
-        self.drop_down_menu_ui.set_image(self.drop_down_menu_ui.drawable_shape.get_fresh_surface())
 
     def show(self):
         """
@@ -878,7 +860,7 @@ class UIDropDownMenu(UIContainer):
         Called by an element's drawable shape when it has a new image surface ready for use,
         normally after a rebuilding/redrawing of some kind.
         """
-        self.current_state.on_fresh_drawable_shape_ready()
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
     def hover_point(self, hover_x: float, hover_y: float) -> bool:
         """

--- a/pygame_gui/elements/ui_horizontal_scroll_bar.py
+++ b/pygame_gui/elements/ui_horizontal_scroll_bar.py
@@ -134,7 +134,7 @@ class UIHorizontalScrollBar(UIElement):
             self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
                                                         ['normal', 'disabled'], self.ui_manager)
 
-        self.set_image(self.drawable_shape.get_fresh_surface())
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
         if self.button_container is None:
             self.button_container = UIContainer(self.background_rect,

--- a/pygame_gui/elements/ui_horizontal_slider.py
+++ b/pygame_gui/elements/ui_horizontal_slider.py
@@ -158,7 +158,7 @@ class UIHorizontalSlider(UIElement):
             self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
                                                         ['normal', 'disabled'], self.ui_manager)
 
-        self.set_image(self.drawable_shape.get_fresh_surface())
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
         if self.button_container is None:
             self.button_container = UIContainer(self.background_rect,

--- a/pygame_gui/elements/ui_scrolling_container.py
+++ b/pygame_gui/elements/ui_scrolling_container.py
@@ -62,7 +62,7 @@ class UIScrollingContainer(UIElement, IContainerLikeInterface):
         self.vert_scroll_bar = None  # type: Union[UIVerticalScrollBar, None]
         self.horiz_scroll_bar = None  # type: Union[UIHorizontalScrollBar, None]
 
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
 
         # this contains the scroll bars and the 'view' container
         self._root_container = UIContainer(relative_rect=relative_rect,

--- a/pygame_gui/elements/ui_status_bar.py
+++ b/pygame_gui/elements/ui_status_bar.py
@@ -97,7 +97,7 @@ class UIStatusBar(UIElement):
         self.background_text = None
         self.foreground_text = None
 
-        self.set_image(None)
+        self._set_image(None)
 
         self.rebuild_from_changed_theme_data()
 
@@ -210,7 +210,7 @@ class UIStatusBar(UIElement):
             self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
                                                         ['normal'], self.ui_manager)
 
-        self.set_image(self.drawable_shape.get_fresh_surface())
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
     def rebuild_from_changed_theme_data(self):
         """

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -297,7 +297,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                     self.shadow_width + self.rounded_corner_offset),
                    drawable_area)
 
-        self.set_image(new_image)
+        self._set_image(new_image)
         self.link_hover_chunks = []
         self.text_box_layout.add_chunks_to_hover_group(self.link_hover_chunks)
 
@@ -370,7 +370,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                         self.shadow_width +
                         self.rounded_corner_offset),
                        drawable_area)
-            self.set_image(new_image)
+            self._set_image(new_image)
 
         mouse_x, mouse_y = self.ui_manager.get_mouse_position()
         should_redraw_from_layout = False
@@ -491,7 +491,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                                                        depth=32)
                     new_image.fill(pygame.Color('#00000000'))
                     basic_blit(new_image, self.image, (0, 0))
-                    self.set_image(new_image)
+                    self._set_image(new_image)
 
                     if self.scroll_bar is not None:
                         self.scroll_bar.set_dimensions((self.scroll_bar.relative_rect.width,
@@ -565,7 +565,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                     self.padding[1] + self.border_width +
                     self.shadow_width + self.rounded_corner_offset),
                    drawable_area)
-        self.set_image(new_image)
+        self._set_image(new_image)
 
     def redraw_from_chunks(self):
         """

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -219,7 +219,7 @@ class UITextEntryLine(UIElement):
                                                         ['normal', 'disabled'], self.ui_manager)
 
         if self.drawable_shape is not None:
-            self.set_image(self.drawable_shape.get_fresh_surface())
+            self._set_image(self.drawable_shape.get_fresh_surface())
             if self.rect.width == -1 or self.rect.height == -1:
                 self.set_dimensions(self.drawable_shape.containing_rect.size)
 

--- a/pygame_gui/elements/ui_tool_tip.py
+++ b/pygame_gui/elements/ui_tool_tip.py
@@ -66,14 +66,14 @@ class UITooltip(UIElement, IUITooltipInterface):
         self.rect_width = self.text_block.rect.size[0]
         super().set_dimensions(self.text_block.rect.size)
 
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
 
     def rebuild(self):
         """
         Rebuild anything that might need rebuilding.
 
         """
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
 
         if self.text_block is not None:
             self.text_block.set_dimensions((self.rect_width, -1))

--- a/pygame_gui/elements/ui_vertical_scroll_bar.py
+++ b/pygame_gui/elements/ui_vertical_scroll_bar.py
@@ -132,7 +132,7 @@ class UIVerticalScrollBar(UIElement):
             self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
                                                         ['normal', 'disabled'], self.ui_manager)
 
-        self.set_image(self.drawable_shape.get_fresh_surface())
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
         if self.button_container is None:
             self.button_container = UIContainer(self.background_rect,

--- a/pygame_gui/elements/ui_window.py
+++ b/pygame_gui/elements/ui_window.py
@@ -59,7 +59,7 @@ class UIWindow(UIElement, IContainerLikeInterface, IWindowInterface):
                                object_id=object_id,
                                element_id=element_id)
 
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
         self.bring_to_front_on_focused = True
 
         self.is_blocking = False  # blocks all clicking events from interacting beyond this window
@@ -510,7 +510,7 @@ class UIWindow(UIElement, IContainerLikeInterface, IWindowInterface):
             self.drawable_shape = RoundedRectangleShape(self.rect, theming_parameters,
                                                         ['normal'], self.ui_manager)
 
-        self.set_image(self.drawable_shape.get_fresh_surface())
+        self._set_image(self.drawable_shape.get_fresh_surface())
 
         self.set_dimensions(self.relative_rect.size)
 

--- a/pygame_gui/windows/ui_colour_picker_dialog.py
+++ b/pygame_gui/windows/ui_colour_picker_dialog.py
@@ -69,7 +69,7 @@ class UIColourChannelEditor(UIElement):
         self.current_value = initial_value
         self.channel_index = channel_index
 
-        self.set_image(self.ui_manager.get_universal_empty_surface())
+        self._set_image(self.ui_manager.get_universal_empty_surface())
 
         self.element_container = UIContainer(relative_rect,
                                              self.ui_manager,
@@ -579,7 +579,7 @@ class UIColourPickerDialog(UIWindow):
         """
         current_colour_surface = pygame.surface.Surface((64, 64), flags=pygame.SRCALPHA, depth=32)
         current_colour_surface.fill(self.current_colour)
-        self.current_colour_image.set_image(current_colour_surface)
+        self.current_colour_image._set_image(current_colour_surface)
 
     def update_saturation_value_square(self):
         """
@@ -601,7 +601,7 @@ class UIColourPickerDialog(UIWindow):
         hue_colour.hsva = (int(self.hue_channel.current_value),
                            100, 100, 100)
         mini_colour_surf.fill(hue_colour, pygame.Rect(1, 0, 1, 1))
-        self.sat_value_square.set_image(pygame.transform.smoothscale(mini_colour_surf, (200, 200)))
+        self.sat_value_square._set_image(pygame.transform.smoothscale(mini_colour_surf, (200, 200)))
 
     def changed_hsv_update_rgb(self):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,14 @@ from pygame_gui.ui_manager import UIManager
 from pygame_gui.core.interfaces import IUIManagerInterface
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def _init_pygame():
     # Enable these variables to test in same environment as Travis.
     # os.environ['SDL_VIDEODRIVER'] = 'dummy'
     # os.environ['SDL_AUDIODRIVER'] = 'disk'
     pygame.init()
-
+    yield
+    pygame.quit()
 
 @pytest.fixture()
 def default_ui_manager() -> IUIManagerInterface:

--- a/tests/test_core/test_ui_element.py
+++ b/tests/test_core/test_ui_element.py
@@ -534,7 +534,7 @@ class TestUIElement:
 
         coloured_surface = pygame.Surface((50, 50))
         coloured_surface.fill(pygame.Color(200, 80, 80, 255))
-        element.set_image(coloured_surface)
+        element._set_image(coloured_surface)
         assert element.pre_debug_image is None
         element.set_visual_debug_mode(True)
         assert element.pre_debug_image is not None
@@ -550,23 +550,23 @@ class TestUIElement:
 
         coloured_surface = pygame.Surface((50, 50), flags=pygame.SRCALPHA, depth=32)
         coloured_surface.fill(pygame.Color(200, 80, 80, 255))
-        element.set_image(coloured_surface)
+        element._set_image(coloured_surface)
 
         after_clip_in_clip_colour = element.image.get_at((15, 25))
         after_clip_out_clip_colour = element.image.get_at((35, 25))
         assert after_clip_in_clip_colour == pygame.Color(200, 80, 80, 255)
         assert after_clip_out_clip_colour == pygame.Color(200, 80, 80, 255)
-        element.set_image_clip(None)
+        element._set_image_clip(None)
         after_clip_in_clip_colour = element.image.get_at((15, 25))
         after_clip_out_clip_colour = element.image.get_at((35, 25))
         assert after_clip_in_clip_colour == pygame.Color(200, 80, 80, 255)
         assert after_clip_out_clip_colour == pygame.Color(200, 80, 80, 255)
-        element.set_image_clip(pygame.Rect(0, 0, 25, 50))
+        element._set_image_clip(pygame.Rect(0, 0, 25, 50))
         after_clip_in_clip_colour = element.image.get_at((15, 25))
         after_clip_out_clip_colour = element.image.get_at((35, 25))
         assert after_clip_in_clip_colour == pygame.Color(200, 80, 80, 255)
         assert after_clip_out_clip_colour == pygame.Color(0, 0, 0, 0)
-        element.set_image_clip(None)
+        element._set_image_clip(None)
         after_clip_in_clip_colour = element.image.get_at((15, 25))
         after_clip_out_clip_colour = element.image.get_at((35, 25))
         assert after_clip_in_clip_colour == pygame.Color(200, 80, 80, 255)
@@ -581,21 +581,21 @@ class TestUIElement:
 
         coloured_surface_1 = pygame.Surface((50, 50), flags=pygame.SRCALPHA, depth=32)
         coloured_surface_1.fill(pygame.Color(200, 80, 80, 255))
-        element.set_image(coloured_surface_1)
+        element._set_image(coloured_surface_1)
         assert element.image.get_at((10, 10)) == pygame.Color(200, 80, 80, 255)
 
         coloured_surface_2 = pygame.Surface((50, 50), flags=pygame.SRCALPHA, depth=32)
         coloured_surface_2.fill(pygame.Color(200, 150, 180, 255))
-        element.set_image_clip(pygame.Rect(0, 0, 25, 50))
-        element.set_image(coloured_surface_2)
+        element._set_image_clip(pygame.Rect(0, 0, 25, 50))
+        element._set_image(coloured_surface_2)
         assert element.image.get_at((10, 10)) == pygame.Color(200, 150, 180, 255)
 
-        element.set_image_clip(pygame.Rect(0, 0, 0, 0))
-        element.set_image(coloured_surface_1)
+        element._set_image_clip(pygame.Rect(0, 0, 0, 0))
+        element._set_image(coloured_surface_1)
         assert element.image == default_ui_manager.get_universal_empty_surface()
 
-        element.set_image_clip(None)
-        element.set_image(None)
+        element._set_image_clip(None)
+        element._set_image(None)
         assert element.image is None
 
     def test_show(self, _init_pygame, default_ui_manager: IUIManagerInterface, _display_surface_return_none):

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -740,6 +740,7 @@ class TestUITextEntryLine:
         text_entry.redraw()
 
     def test_update(self,  _init_pygame):
+        pygame.display.init()
         manager = UIManager((800, 600), os.path.join("tests", "data",
                                                      "themes",
                                                      "ui_text_entry_line_non_default.json"))
@@ -765,6 +766,7 @@ class TestUITextEntryLine:
         text_entry.update(0.01)
 
     def test_update_after_long_wait(self,  _init_pygame):
+        pygame.display.init()
         manager = UIManager((800, 600), os.path.join("tests", "data",
                                                      "themes",
                                                      "ui_text_entry_line_non_default.json"))


### PR DESCRIPTION
To resolve #258 .

Essentially trying to make the public interface less confusing for users due to the legacy pygame sprite attribute names being not quite a perfect match for the complexity of a UI element.

Now only UIImage has a public `.set_image()` which does what you might expect for `set_image()`. The old `set_image()` function is is now hidden away in protected method. Calling set_image on a non-UIImage will raise a deprecation warning until 0.8.0
