### PR TITLE
change text key word arguments param into dictionary on init

### DIFF
--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -43,7 +43,8 @@ class UILabel(UIElement, IUITextOwnerInterface):
                  object_id: Optional[Union[ObjectID, str]] = None,
                  anchors: Optional[Dict[str, Union[str, UIElement]]] = None,
                  visible: int = 1,
-                 **text_kwargs: str):
+                 *,
+                 text_kwargs: Dict[str, str] = None):
 
         super().__init__(relative_rect, manager, container,
                          starting_height=1,
@@ -61,7 +62,9 @@ class UILabel(UIElement, IUITextOwnerInterface):
         self.dynamic_dimensions_orig_top_left = relative_rect.topleft
 
         self.text = text
-        self.text_kwargs = text_kwargs
+        self.text_kwargs = {}
+        if text_kwargs is not None:
+            self.text_kwargs = text_kwargs
 
         # initialise theme params
         self.font = None

--- a/tests/test_elements/test_ui_label.py
+++ b/tests/test_elements/test_ui_label.py
@@ -18,6 +18,12 @@ class TestUILabel:
                         manager=default_ui_manager)
         assert label.image is not None
 
+        label_with_kwargs = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                    text="Hello %{name}",
+                                    manager=default_ui_manager,
+                                    text_kwargs={"name": "Dan"})
+        assert label_with_kwargs.image is not None
+
     def test_set_text(self, _init_pygame, default_ui_manager,
                       _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
@@ -242,8 +248,8 @@ class TestUILabel:
 
         assert label.image is not None
 
-    def test_get_objectID(self, _init_pygame, default_ui_manager,
-                          _display_surface_return_none):
+    def test_get_object_id(self, _init_pygame, default_ui_manager,
+                           _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=default_ui_manager,


### PR DESCRIPTION
This should future proof us in case we need to add more params to the initialisation function later. This should be extensible to the other elements with text too.


Related to: #270