### PR TITLE
Add translation text key word argument dictionary params

### DIFF
--- a/pygame_gui/core/interfaces/manager_interface.py
+++ b/pygame_gui/core/interfaces/manager_interface.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, List, Union, Dict, Set
+from typing import Tuple, List, Union, Dict, Set, Optional
 
 import pygame
 
@@ -226,13 +226,18 @@ class IUIManagerInterface(metaclass=ABCMeta):
     def create_tool_tip(self,
                         text: str,
                         position: Tuple[int, int],
-                        hover_distance: Tuple[int, int]) -> IUITooltipInterface:
+                        hover_distance: Tuple[int, int],
+                        *,
+                        text_kwargs: Optional[Dict[str, str]] = None) -> IUITooltipInterface:
         """
         Creates a tool tip ands returns it.
 
         :param text: The tool tips text, can utilise the HTML subset used in all UITextBoxes.
         :param position: The screen position to create the tool tip for.
         :param hover_distance: The distance we should hover away from our target position.
+        :param text_kwargs: a dictionary of variable arguments to pass to the translated string
+                            useful when you have multiple translations that need variables inserted
+                            in the middle.
 
         :return: A tool tip placed somewhere on the screen.
 

--- a/pygame_gui/core/text/text_box_layout_row.py
+++ b/pygame_gui/core/text/text_box_layout_row.py
@@ -18,7 +18,7 @@ class TextBoxLayoutRow(pygame.Rect):
         self.line_spacing = line_spacing
         self.row_index = row_index
         self.layout = layout
-        self.items = []
+        self.items: TextLayoutRect = []
 
         self.letter_count = 0
 

--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -33,6 +33,9 @@ class UILabel(UIElement, IUITextOwnerInterface):
     :param anchors: A dictionary describing what this element's relative_rect is relative to.
     :param visible: Whether the element is visible by default. Warning - container visibility
                     may override this.
+    :param text_kwargs: a dictionary of variable arguments to pass to the translated string
+                        useful when you have multiple translations that need variables inserted
+                        in the middle.
     """
 
     def __init__(self, relative_rect: pygame.Rect,
@@ -44,7 +47,7 @@ class UILabel(UIElement, IUITextOwnerInterface):
                  anchors: Optional[Dict[str, Union[str, UIElement]]] = None,
                  visible: int = 1,
                  *,
-                 text_kwargs: Dict[str, str] = None):
+                 text_kwargs: Optional[Dict[str, str]] = None):
 
         super().__init__(relative_rect, manager, container,
                          starting_height=1,
@@ -86,19 +89,26 @@ class UILabel(UIElement, IUITextOwnerInterface):
 
         self.rebuild_from_changed_theme_data()
 
-    def set_text(self, text: str, **text_kwargs: str):
+    def set_text(self, text: str, *, text_kwargs: Optional[Dict[str, str]] = None):
         """
         Changes the string displayed by the label element. Labels do not support HTML styling.
 
         :param text: the text to set the label to.
+        :param text_kwargs: a dictionary of variable arguments to pass to the translated string
+                            useful when you have multiple translations that need variables inserted
+                            in the middle.
 
         """
         any_changed = False
         if text != self.text:
             self.text = text
             any_changed = True
-        if text_kwargs != self.text_kwargs:
-            self.text_kwargs = text_kwargs
+        if text_kwargs is not None:
+            if text_kwargs != self.text_kwargs:
+                self.text_kwargs = text_kwargs
+                any_changed = True
+        elif self.text_kwargs != {}:
+            self.text_kwargs = {}
             any_changed = True
 
         if any_changed:

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -67,6 +67,9 @@ class UITextBox(UIElement, IUITextOwnerInterface):
     :param anchors: A dictionary describing what this element's relative_rect is relative to.
     :param visible: Whether the element is visible by default. Warning - container visibility
                     may override this.
+    :param text_kwargs: a dictionary of variable arguments to pass to the translated text
+                        useful when you have multiple translations that need variables inserted
+                        in the middle.
     """
 
     def __init__(self,
@@ -81,7 +84,8 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                  anchors: Optional[Dict[str, Union[str, UIElement]]] = None,
                  visible: int = 1,
                  *,
-                 pre_parsing_enabled: bool = True):
+                 pre_parsing_enabled: bool = True,
+                 text_kwargs: Optional[Dict[str, str]] = None):
 
         super().__init__(relative_rect, manager, container,
                          starting_height=layer_starting_height,
@@ -97,6 +101,9 @@ class UITextBox(UIElement, IUITextOwnerInterface):
 
         self.html_text = html_text
         self.appended_text = ""
+        self.text_kwargs = {}
+        if text_kwargs is not None:
+            self.text_kwargs = text_kwargs
         self.font_dict = self.ui_theme.get_font_dictionary()
 
         self._pre_parsing_enabled = pre_parsing_enabled
@@ -519,7 +526,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
         rendered text.
         """
 
-        self.parser.feed(self._pre_parse_text(translate(self.html_text) + self.appended_text))
+        self.parser.feed(self._pre_parse_text(translate(self.html_text, **self.text_kwargs) + self.appended_text))
 
         self.text_box_layout = TextBoxLayout(self.parser.layout_rect_queue,
                                              pygame.Rect((0, 0), (self.text_wrap_rect[2],
@@ -1057,8 +1064,12 @@ class UITextBox(UIElement, IUITextOwnerInterface):
     def get_object_id(self) -> str:
         return self.most_specific_combined_id
 
-    def set_text(self, html_text: str):
+    def set_text(self, html_text: str, *, text_kwargs: Optional[Dict[str, str]] = None):
         self.html_text = html_text
+        if text_kwargs is not None:
+            self.text_kwargs = text_kwargs
+        else:
+            self.text_kwargs = {}
         self.appended_text = ""  # clear appended text as it feels odd to set the text and still have appended text
         self._reparse_and_rebuild()
 

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -89,7 +89,7 @@ class UITextEntryLine(UIElement):
 
         self.text = ""
         if initial_text is not None:
-            self.text = initial_text
+            self.text = translate(initial_text)
         self.is_text_hidden = False
         self.hidden_text_char = '●'
         self.placeholder_text = ""
@@ -216,7 +216,7 @@ class UITextEntryLine(UIElement):
                               'border_width': self.border_width,
                               'shadow_width': self.shadow_width,
                               'font': self.font,
-                              'text': display_text if len(display_text) > 0 else self.placeholder_text,
+                              'text': display_text if len(display_text) > 0 else translate(self.placeholder_text),
                               'text_width': -1,
                               'text_horiz_alignment': 'left',
                               'text_vert_alignment': 'centre',
@@ -276,7 +276,8 @@ class UITextEntryLine(UIElement):
                 if self.is_text_hidden:
                     display_text = self.hidden_text_char * len(self.text)
                 if self.drawable_shape is not None:
-                    self.drawable_shape.set_text(display_text if len(display_text) > 0 else self.placeholder_text)
+                    self.drawable_shape.set_text(display_text if len(display_text) > 0
+                                                 else translate(self.placeholder_text))
                     self.drawable_shape.text_box_layout.set_cursor_position(self.edit_position)
                     self.drawable_shape.apply_active_text_changes()
             else:
@@ -366,7 +367,7 @@ class UITextEntryLine(UIElement):
         self.text_entered = False
         if len(self.text) == 0:
             if self.drawable_shape is not None:
-                self.drawable_shape.set_text(self.placeholder_text)
+                self.drawable_shape.set_text(translate(self.placeholder_text))
                 self.drawable_shape.text_box_layout.set_cursor_position(self.edit_position)
                 self.drawable_shape.apply_active_text_changes()
         self.redraw()
@@ -997,7 +998,7 @@ class UITextEntryLine(UIElement):
 
     def disable(self):
         """
-        Disables the button so that it is no longer interactive.
+        Disables the element so that it is no longer interactive.
         """
         if self.is_enabled:
             self.is_enabled = False
@@ -1017,7 +1018,7 @@ class UITextEntryLine(UIElement):
 
     def enable(self):
         """
-        Re-enables the button so we can once again interact with it.
+        Re-enables the element so we can once again interact with it.
         """
         if not self.is_enabled:
             self.is_enabled = True
@@ -1033,8 +1034,12 @@ class UITextEntryLine(UIElement):
             self.font = font
             self.rebuild()
         else:
+            display_text = self.text
+            if self.is_text_hidden:
+                display_text = self.hidden_text_char * len(self.text)
             if self.drawable_shape is not None:
-                self.drawable_shape.set_text(translate(self.text))
+                self.drawable_shape.set_text(display_text if len(display_text) > 0
+                                             else translate(self.placeholder_text))
 
     def clear(self):
         self.set_text("")

--- a/pygame_gui/elements/ui_tool_tip.py
+++ b/pygame_gui/elements/ui_tool_tip.py
@@ -30,6 +30,9 @@ class UITooltip(UIElement, IUITooltipInterface):
     :param parent_element: The element this element 'belongs to' in the theming hierarchy.
     :param object_id: A custom defined ID for fine tuning of theming.
     :param anchors: A dictionary describing what this element's relative_rect is relative to.
+    :param text_kwargs: a dictionary of variable arguments to pass to the translated text
+                        useful when you have multiple translations that need variables inserted
+                        in the middle.
 
     """
     def __init__(self,
@@ -38,7 +41,9 @@ class UITooltip(UIElement, IUITooltipInterface):
                  manager: Optional[IUIManagerInterface] = None,
                  parent_element: Optional[UIElement] = None,
                  object_id: Optional[Union[ObjectID, str]] = None,
-                 anchors: Optional[Dict[str, Union[str, UIElement]]] = None):
+                 anchors: Optional[Dict[str, Union[str, UIElement]]] = None,
+                 *,
+                 text_kwargs: Dict[str, str] = None):
 
         super().__init__(relative_rect=pygame.Rect((0, 0), (-1, -1)),
                          manager=manager,
@@ -62,7 +67,8 @@ class UITooltip(UIElement, IUITooltipInterface):
                                     pygame.Rect(0, 0, self.rect_width, -1),
                                     manager=self.ui_manager,
                                     layer_starting_height=self._layer,
-                                    parent_element=self)
+                                    parent_element=self,
+                                    text_kwargs=text_kwargs)
 
         self.rect_width = self.text_block.rect.size[0]
         super().set_dimensions(self.text_block.rect.size)

--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -521,7 +521,9 @@ class UIManager(IUIManagerInterface):
         return self.universal_empty_surface
 
     def create_tool_tip(self, text: str, position: Tuple[int, int],
-                        hover_distance: Tuple[int, int]) -> IUITooltipInterface:
+                        hover_distance: Tuple[int, int],
+                        *,
+                        text_kwargs: Optional[Dict[str, str]] = None) -> IUITooltipInterface:
         """
         Creates a tool tip ands returns it. Have hidden this away in the manager so we can call it
         from other UI elements and create tool tips without creating cyclical import problems.
@@ -529,10 +531,13 @@ class UIManager(IUIManagerInterface):
         :param text: The tool tips text, can utilise the HTML subset used in all UITextBoxes.
         :param position: The screen position to create the tool tip for.
         :param hover_distance: The distance we should hover away from our target position.
+        :param text_kwargs: a dictionary of variable arguments to pass to the translated string
+                            useful when you have multiple translations that need variables inserted
+                            in the middle.
 
         :return: A tool tip placed somewhere on the screen.
         """
-        tool_tip = UITooltip(text, hover_distance, self)
+        tool_tip = UITooltip(text, hover_distance, self, text_kwargs=text_kwargs)
         tool_tip.find_valid_position(pygame.math.Vector2(position[0], position[1]))
         return tool_tip
 

--- a/pygame_gui/windows/ui_confirmation_dialog.py
+++ b/pygame_gui/windows/ui_confirmation_dialog.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 import pygame
 
@@ -28,6 +28,9 @@ class UIConfirmationDialog(UIWindow):
     :param object_id: A custom defined ID for fine tuning of theming. Defaults to
                       '#confirmation_dialog'.
     :param visible: Whether the element is visible by default.
+    :param long_desc_text_kwargs: a dictionary of variable arguments to pass to the translated string
+                                  useful when you have multiple translations that need variables inserted
+                                  in the middle.
     """
 
     def __init__(self, rect: pygame.Rect,
@@ -38,7 +41,9 @@ class UIConfirmationDialog(UIWindow):
                  action_short_name: str = 'pygame-gui.OK',
                  blocking: bool = True,
                  object_id: Union[ObjectID, str] = ObjectID('#confirmation_dialog', None),
-                 visible: int = 1):
+                 visible: int = 1,
+                 action_long_desc_text_kwargs: Optional[Dict[str, str]] = None
+                 ):
 
         super().__init__(rect, manager,
                          window_display_title=window_title,
@@ -86,7 +91,8 @@ class UIConfirmationDialog(UIWindow):
                                            anchors={'left': 'left',
                                                     'right': 'right',
                                                     'top': 'top',
-                                                    'bottom': 'bottom'})
+                                                    'bottom': 'bottom'},
+                                           text_kwargs=action_long_desc_text_kwargs)
 
         self.set_blocking(blocking)
 

--- a/pygame_gui/windows/ui_message_window.py
+++ b/pygame_gui/windows/ui_message_window.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union, Optional
+from typing import Union, Optional, Dict
 
 import pygame
 
@@ -27,7 +27,8 @@ class UIMessageWindow(UIWindow):
                  *,
                  window_title: str = 'pygame-gui.message_window_title_bar',
                  object_id: Union[ObjectID, str] = ObjectID('#message_window', None),
-                 visible: int = 1):
+                 visible: int = 1,
+                 html_message_text_kwargs: Optional[Dict[str, str]] = None):
 
         super().__init__(rect, manager,
                          window_display_title=window_title,
@@ -71,8 +72,8 @@ class UIMessageWindow(UIWindow):
                                     anchors={"left": "left",
                                              "top": "top",
                                              "right": "right",
-                                             "bottom": "bottom"}
-                                    )
+                                             "bottom": "bottom"},
+                                    text_kwargs=html_message_text_kwargs)
 
     def process_event(self, event: pygame.event.Event) -> bool:
         """

--- a/tests/test_elements/test_ui_button.py
+++ b/tests/test_elements/test_ui_button.py
@@ -4,6 +4,8 @@ import pytest
 import pygame
 import pygame_gui
 
+import i18n
+
 from tests.shared_comparators import compare_surfaces
 
 from pygame_gui.ui_manager import UIManager
@@ -20,6 +22,24 @@ class TestUIButton:
                           text="Test Button",
                           tool_tip_text="This is a test of the button's tool tip functionality.")
         assert button.image is not None
+
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        button_with_kwargs = UIButton(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                      text="translation.test_hello",
+                                      manager=default_ui_manager,
+                                      text_kwargs={"name": "World"})
+        assert button_with_kwargs.image is not None
+        assert button_with_kwargs.drawable_shape.theming['text'] == "Hello World"
+
+    def test_kwargs_set_text(self, _init_pygame, default_ui_manager,
+                             _display_surface_return_none):
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        button = UIButton(relative_rect=pygame.Rect(100, 100, 150, 30),
+                          text="Test Button",
+                          manager=default_ui_manager)
+        button.set_text("translation.test_hello", text_kwargs={"name": "World"})
+        assert button.image is not None
+        assert button.drawable_shape.theming['text'] == "Hello World"
 
     @pytest.mark.filterwarnings("ignore:DeprecationWarning")
     def test_set_any_images_from_theme(self, _init_pygame, _display_surface_return_none):

--- a/tests/test_elements/test_ui_button.py
+++ b/tests/test_elements/test_ui_button.py
@@ -31,6 +31,13 @@ class TestUIButton:
         assert button_with_kwargs.image is not None
         assert button_with_kwargs.drawable_shape.theming['text'] == "Hello World"
 
+        button_with_tt_kwargs = UIButton(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                         text="Test Button",
+                                         manager=default_ui_manager,
+                                         tool_tip_text="translation.test_hello",
+                                         tool_tip_text_kwargs={"name": "World"})
+        assert button_with_tt_kwargs.image is not None
+
     def test_kwargs_set_text(self, _init_pygame, default_ui_manager,
                              _display_surface_return_none):
         i18n.add_translation('translation.test_hello', 'Hello %{name}')
@@ -40,6 +47,10 @@ class TestUIButton:
         button.set_text("translation.test_hello", text_kwargs={"name": "World"})
         assert button.image is not None
         assert button.drawable_shape.theming['text'] == "Hello World"
+
+        button.set_text("Clear args")
+        assert button.image is not None
+        assert button.drawable_shape.theming['text'] == "Clear args"
 
     @pytest.mark.filterwarnings("ignore:DeprecationWarning")
     def test_set_any_images_from_theme(self, _init_pygame, _display_surface_return_none):

--- a/tests/test_elements/test_ui_label.py
+++ b/tests/test_elements/test_ui_label.py
@@ -2,6 +2,8 @@ import os
 import pytest
 import pygame
 
+import i18n
+
 from tests.shared_comparators import compare_surfaces
 
 from pygame_gui.ui_manager import UIManager
@@ -18,11 +20,13 @@ class TestUILabel:
                         manager=default_ui_manager)
         assert label.image is not None
 
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
         label_with_kwargs = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
-                                    text="Hello %{name}",
+                                    text="translation.test_hello",
                                     manager=default_ui_manager,
-                                    text_kwargs={"name": "Dan"})
+                                    text_kwargs={"name": "World"})
         assert label_with_kwargs.image is not None
+        assert label_with_kwargs.drawable_shape.theming['text'] == "Hello World"
 
     def test_set_text(self, _init_pygame, default_ui_manager,
                       _display_surface_return_none):
@@ -41,11 +45,13 @@ class TestUILabel:
 
     def test_kwargs_set_text(self, _init_pygame, default_ui_manager,
                              _display_surface_return_none):
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),
                         text="Test Label",
                         manager=default_ui_manager)
-        label.set_text("Hello %{name}", name="Dan")
+        label.set_text("translation.test_hello", text_kwargs={"name": "World"})
         assert label.image is not None
+        assert label.drawable_shape.theming['text'] == "Hello World"
 
     def test_rebuild(self, _init_pygame, default_ui_manager,
                      _display_surface_return_none):

--- a/tests/test_elements/test_ui_label.py
+++ b/tests/test_elements/test_ui_label.py
@@ -53,6 +53,10 @@ class TestUILabel:
         assert label.image is not None
         assert label.drawable_shape.theming['text'] == "Hello World"
 
+        label.set_text("Clear args")
+        assert label.image is not None
+        assert label.drawable_shape.theming['text'] == "Clear args"
+
     def test_rebuild(self, _init_pygame, default_ui_manager,
                      _display_surface_return_none):
         label = UILabel(relative_rect=pygame.Rect(100, 100, 150, 30),

--- a/tests/test_elements/test_ui_text_box.py
+++ b/tests/test_elements/test_ui_text_box.py
@@ -3,10 +3,13 @@ import os
 import pygame
 import pytest
 
+import i18n
+
 import pygame_gui
 from pygame_gui.elements.ui_text_box import UITextBox
 from pygame_gui.ui_manager import UIManager
 from tests.shared_comparators import compare_surfaces
+from pygame_gui.core.text.text_line_chunk import TextLineChunkFTFont
 
 from pygame_gui import UITextEffectType
 
@@ -23,6 +26,15 @@ class TestUITextBox:
                              relative_rect=pygame.Rect(100, 100, 200, 300),
                              manager=default_ui_manager)
         assert text_box.image is not None
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        text_box_with_kwargs = UITextBox(relative_rect=pygame.Rect(100, 100, 150, 30),
+                                         html_text="translation.test_hello",
+                                         manager=default_ui_manager,
+                                         text_kwargs={"name": "World"})
+        assert text_box_with_kwargs.image is not None
+        text_chunk = text_box_with_kwargs.text_box_layout.layout_rows[0].items[0]
+        assert isinstance(text_chunk, TextLineChunkFTFont)
+        assert text_chunk.text == "Hello World"
 
     def test_set_text(self, _init_pygame: None,
                       default_ui_manager: UIManager,
@@ -37,6 +49,21 @@ class TestUITextBox:
 
         text_box.set_text("<b>Changed text</b>")
         assert text_box.image is not None
+
+    def test_kwargs_set_text(self, _init_pygame, default_ui_manager,
+                             _display_surface_return_none):
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        default_ui_manager.preload_fonts([{"name": "fira_code", "size:": 14, "style": "bold"},
+                                          {"name": "fira_code", "size:": 14, "style": "italic"}])
+        text_box = UITextBox(html_text="<font color=#FF0000>Some text</font> in a <b>bold box</b> using colours and "
+                                       "<i>styles</i>.",
+                             relative_rect=pygame.Rect(100, 100, 200, 300),
+                             manager=default_ui_manager)
+        text_box.set_text("translation.test_hello", text_kwargs={"name": "World"})
+        assert text_box.image is not None
+        text_chunk = text_box.text_box_layout.layout_rows[0].items[0]
+        assert isinstance(text_chunk, TextLineChunkFTFont)
+        assert text_chunk.text == "Hello World"
 
     def test_clear(self, _init_pygame: None,
                    default_ui_manager: UIManager,

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -3,6 +3,8 @@ import pytest
 import pygame
 import platform
 
+import i18n
+
 from tests.shared_comparators import compare_surfaces
 
 from pygame_gui.ui_manager import UIManager
@@ -20,6 +22,7 @@ class TestUITextEntryLine:
         assert text_entry.image is not None
 
     def test_placeholder_text(self, _init_pygame, default_ui_manager):
+
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
                                      manager=default_ui_manager,
                                      placeholder_text="Enter name...")
@@ -41,6 +44,14 @@ class TestUITextEntryLine:
         text_entry.unfocus()
 
         assert text_entry.drawable_shape.theming['text'] == "Enter name..."
+
+        i18n.add_translation('translation.enter_age', 'Enter age...')
+
+        text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),
+                                     manager=default_ui_manager,
+                                     placeholder_text='translation.enter_age')
+        assert text_entry.image is not None
+        assert text_entry.drawable_shape.theming['text'] == "Enter age..."
 
     def test_initial_text(self, _init_pygame, default_ui_manager):
         text_entry = UITextEntryLine(relative_rect=pygame.Rect(100, 100, 200, 30),

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -1159,6 +1159,12 @@ class TestUITextEntryLine:
 
         default_ui_manager.set_locale('ja')
 
+        text_entry.set_text_hidden(True)
+
+        default_ui_manager.set_locale('en')
+
+        text_entry.set_text_hidden(False)
+
         assert text_entry.get_text() == "Some basic text"
 
 

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -1159,9 +1159,10 @@ class TestUITextEntryLine:
 
         default_ui_manager.set_locale('ja')
 
+        default_ui_manager.set_locale('en')
         text_entry.set_text_hidden(True)
 
-        default_ui_manager.set_locale('en')
+        default_ui_manager.set_locale('fr')
 
         text_entry.set_text_hidden(False)
 

--- a/tests/test_elements/test_ui_tool_tip.py
+++ b/tests/test_elements/test_ui_tool_tip.py
@@ -2,8 +2,11 @@ import os
 import pytest
 import pygame
 
+import i18n
+
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.elements.ui_tool_tip import UITooltip
+from pygame_gui.core.text.text_line_chunk import TextLineChunkFTFont
 
 
 class TestUIToolTip:
@@ -13,6 +16,16 @@ class TestUIToolTip:
                              hover_distance=(0, 10),
                              manager=default_ui_manager)
         assert tool_tip.text_block.image is not None
+
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        tool_tip = UITooltip(html_text="translation.test_hello",
+                             hover_distance=(0, 10),
+                             manager=default_ui_manager,
+                             text_kwargs={"name": "World"})
+        assert tool_tip.text_block.image is not None
+        text_chunk = tool_tip.text_block.text_box_layout.layout_rows[0].items[0]
+        assert isinstance(text_chunk, TextLineChunkFTFont)
+        assert text_chunk.text == "Hello World"
 
     def test_rebuild(self, _init_pygame, default_ui_manager, _display_surface_return_none):
         tool_tip = UITooltip(html_text="A tip about tools.",

--- a/tests/test_windows/test_ui_confirmation_dialog.py
+++ b/tests/test_windows/test_ui_confirmation_dialog.py
@@ -3,10 +3,13 @@ import pygame
 import pytest
 import pygame_gui
 
+import i18n
+
 from tests.shared_comparators import compare_surfaces
 
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.windows import UIConfirmationDialog
+from pygame_gui.core.text.text_line_chunk import TextLineChunkFTFont
 
 
 class TestUIConfirmationDialog:
@@ -20,6 +23,19 @@ class TestUIConfirmationDialog:
                              manager=default_ui_manager,
                              window_title="Confirm",
                              action_short_name="Confirm")
+
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+
+        confirmation_dialog = UIConfirmationDialog(rect=pygame.Rect(100, 100, 400, 300),
+                                                   action_long_desc="translation.test_hello",
+                                                   manager=default_ui_manager,
+                                                   window_title="Confirm",
+                                                   action_short_name="Confirm",
+                                                   action_long_desc_text_kwargs={"name": "World"})
+        assert confirmation_dialog.confirmation_text.image is not None
+        text_chunk = confirmation_dialog.confirmation_text.text_box_layout.layout_rows[0].items[0]
+        assert isinstance(text_chunk, TextLineChunkFTFont)
+        assert text_chunk.text == "Hello World"
 
     def test_create_too_small(self, _init_pygame, default_ui_manager,
                               _display_surface_return_none):

--- a/tests/test_windows/test_ui_message_window.py
+++ b/tests/test_windows/test_ui_message_window.py
@@ -2,11 +2,13 @@ import os
 import pygame
 import pytest
 
+import i18n
+
 from tests.shared_comparators import compare_surfaces
 
 from pygame_gui.ui_manager import UIManager
 from pygame_gui.windows.ui_message_window import UIMessageWindow
-
+from pygame_gui.core.text.text_line_chunk import TextLineChunkFTFont
 
 
 class TestUIMessageWindow:
@@ -16,11 +18,24 @@ class TestUIMessageWindow:
         default_ui_manager.preload_fonts([{'name': 'fira_code',
                                            'point_size': 14,
                                            'style': 'bold'}])
+
         UIMessageWindow(rect=pygame.Rect(100, 100, 250, 300),
                         window_title="Test Message",
                         html_message="This is a <b>bold</b> test "
                                      "of the message box functionality.",
                         manager=default_ui_manager)
+
+        i18n.add_translation('translation.test_hello', 'Hello %{name}')
+        message_window = UIMessageWindow(rect=pygame.Rect(100, 100, 250, 300),
+                                         window_title="Test Message",
+                                         html_message="translation.test_hello",
+                                         manager=default_ui_manager,
+                                         html_message_text_kwargs={"name": "World"})
+
+        assert message_window.text_block.image is not None
+        text_chunk = message_window.text_block.text_box_layout.layout_rows[0].items[0]
+        assert isinstance(text_chunk, TextLineChunkFTFont)
+        assert text_chunk.text == "Hello World"
 
     def test_create_too_small(self, _init_pygame, default_ui_manager,
                               _display_surface_return_none):


### PR DESCRIPTION
Allows most elements with text to accept a dictionary of keyword arguments that are passed to the translation engine for insertion into translated strings.

A keyword argument dictionary of string to strings was chosen over raw keyword arguments as it lets us be more flexible in adding arguments to elements in the future.

fixes #270

Usage Example:

```
message_window = UIMessageWindow(rect=pygame.Rect(100, 100, 250, 300),
                                         window_title="Test Message",
                                         html_message="app_translations.test_hello",
                                         manager=default_ui_manager,
                                         html_message_text_kwargs={"name": "World"})

```

Example `app_translation.en.json` file:

```
{
  "en": {
    "test_hello": "Hello %{name}"
  }
}
```
