### PR TITLE
Make sure effect ids are copied when splitting chunks

### DIFF
--- a/pygame_gui/core/text/text_line_chunk.py
+++ b/pygame_gui/core/text/text_line_chunk.py
@@ -516,6 +516,7 @@ class TextLineChunkFTFont(TextLayoutRect):
         right_side_chunk.target_surface = target_surface
         right_side_chunk.target_surface_area = target_surface_area
         right_side_chunk.should_centre_from_baseline = baseline_centred
+        right_side_chunk.effect_id = self.effect_id
         return right_side_chunk
 
     def clear(self, optional_rect: Optional[pygame.Rect] = None):


### PR DESCRIPTION
Noticed that effect IDs weren't getting copied when chunks were split. 

This fixes that.