### PR TITLE
Added parameter "allowed_suffixes" parameter to UIFileDialog

### DIFF
--- a/pygame_gui/windows/ui_file_dialog.py
+++ b/pygame_gui/windows/ui_file_dialog.py
@@ -38,6 +38,7 @@ class UIFileDialog(UIWindow):
                  rect: pygame.Rect,
                  manager: Optional[IUIManagerInterface],
                  window_title: str = 'pygame-gui.file_dialog_title_bar',
+                 allow_suffix: set[str] = {""},
                  initial_file_path: Optional[str] = None,
                  object_id: Union[ObjectID, str] = ObjectID('#file_dialog', None),
                  allow_existing_files_only: bool = False,
@@ -63,7 +64,7 @@ class UIFileDialog(UIWindow):
 
         self.delete_confirmation_dialog = None  # type: Union[UIConfirmationDialog, None]
         self.current_file_path = None  # type: Union[Path, None]
-
+        self.allow_suffix = allow_suffix
         if initial_file_path is not None:
             pathed_initial_file_path = Path(initial_file_path)
             if pathed_initial_file_path.exists() and not pathed_initial_file_path.is_file():
@@ -220,7 +221,7 @@ class UIFileDialog(UIWindow):
             directories_on_path_tuples = [(f, '#directory_list_item') for f in directories_on_path]
 
             files_on_path = [f.name for f in Path(self.current_directory_path).iterdir()
-                             if f.is_file()]
+                             if f.is_file() and any([f.name.endswith(x) for x in self.allow_suffix])]
             files_on_path = sorted(files_on_path, key=str.casefold)
             files_on_path_tuples = [(f, '#file_list_item') for f in files_on_path]
 

--- a/pygame_gui/windows/ui_file_dialog.py
+++ b/pygame_gui/windows/ui_file_dialog.py
@@ -38,7 +38,7 @@ class UIFileDialog(UIWindow):
                  rect: pygame.Rect,
                  manager: Optional[IUIManagerInterface],
                  window_title: str = 'pygame-gui.file_dialog_title_bar',
-                 allow_suffix: set[str] = {""},
+                 allowed_suffixes: set[str] = {""},
                  initial_file_path: Optional[str] = None,
                  object_id: Union[ObjectID, str] = ObjectID('#file_dialog', None),
                  allow_existing_files_only: bool = False,
@@ -64,7 +64,7 @@ class UIFileDialog(UIWindow):
 
         self.delete_confirmation_dialog = None  # type: Union[UIConfirmationDialog, None]
         self.current_file_path = None  # type: Union[Path, None]
-        self.allow_suffix = allow_suffix
+        self.allowed_suffixes = allowed_suffixes
         if initial_file_path is not None:
             pathed_initial_file_path = Path(initial_file_path)
             if pathed_initial_file_path.exists() and not pathed_initial_file_path.is_file():
@@ -221,7 +221,7 @@ class UIFileDialog(UIWindow):
             directories_on_path_tuples = [(f, '#directory_list_item') for f in directories_on_path]
 
             files_on_path = [f.name for f in Path(self.current_directory_path).iterdir()
-                             if f.is_file() and any([f.name.endswith(x) for x in self.allow_suffix])]
+                             if f.is_file() and any([f.name.endswith(x) for x in self.allowed_suffixes])]
             files_on_path = sorted(files_on_path, key=str.casefold)
             files_on_path_tuples = [(f, '#file_list_item') for f in files_on_path]
 


### PR DESCRIPTION
Now you're able to show files iin UIFileDialog with specific extensions only

Example:
```python3
file_picker_dialog = pygui.windows.UIFileDialog(
    rect=centered_rect(500, 500, window.get_size()),
    manager=manager,
    initial_file_path=str("C:\\"),
    # --
    allowed_suffixes={".mp4", ".mp3"}
)
```
Will only show files with `.mp4` and `.mp3` suffixes