### PR TITLE
Default UIPanel starting_layer_height to 1

### DIFF
--- a/pygame_gui/elements/ui_panel.py
+++ b/pygame_gui/elements/ui_panel.py
@@ -42,7 +42,7 @@ class UIPanel(UIElement, IContainerLikeInterface):
     """
     def __init__(self,
                  relative_rect: pygame.Rect,
-                 starting_layer_height: int,
+                 starting_layer_height: int = 1,
                  manager: Optional[IUIManagerInterface] = None,
                  *,
                  element_id: str = 'panel',


### PR DESCRIPTION
Adds a default value of 1 to the `starting_layer_height`  parameter in the `pygame_gui.elements.UIPanel`  constructor.

This should be consistent with all other element classes in the `pygame_gui.elements` package, which default this parameter to 1 (if exposing it as an __init__ argument).

Resolves issue #356.