### PR TITLE
Add pytest-benchmark to test dependency doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ For running the tests you will need:
 
  - pytest
  - pytest-cov
+ - pytest-benchmark
  
  
  All should be pip installable.


### PR DESCRIPTION
This adds the missing pytest-benchmark dependency (required to run unit tests using pytest) to the CONTRIBUTING.md documentation.

Resolves issue #358.