### PR TITLE
Text selection improvements

### DIFF
--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -584,8 +584,23 @@ class UITextEntryLine(UIElement):
         if event.key == pygame.K_HOME or (event.key == pygame.K_LEFT
             and (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META)
             ):
+            # include case when shift held down to select everything to start
+            # of current line.
             if abs(self.select_range[0] - self.select_range[1]) > 0:
-                self.select_range = [0, 0]
+                if event.mod & pygame.KMOD_SHIFT:
+                    if self.edit_position == self.select_range[1]:
+                        # undo selection to right, create to left
+                        self.select_range = [0, self.select_range[0]]
+                    else:
+                        # extend left
+                        self.select_range = [0, self.select_range[1]]
+                else:
+                    self.select_range = [0, 0]
+            else:
+                if event.mod & pygame.KMOD_SHIFT:
+                    self.select_range = [0, self.edit_position]
+                else:
+                    self.select_range = [0, 0]
             self.edit_position = 0
             self.cursor_has_moved_recently = True
             consumed_event = True
@@ -593,8 +608,21 @@ class UITextEntryLine(UIElement):
             and (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META)
             ):
             if abs(self.select_range[0] - self.select_range[1]) > 0:
-                self.select_range = [0, 0]
-            self.edit_position = 0
+                if event.mod & pygame.KMOD_SHIFT:
+                    if self.edit_position == self.select_range[0]:
+                        # undo selection to left, create to right
+                        self.select_range = [self.select_range[1], len(self.text)]
+                    else:
+                        # extend right
+                        self.select_range = [self.select_range[0], len(self.text)]
+                else:
+                    self.select_range = [0, 0]
+            else:
+                if event.mod & pygame.KMOD_SHIFT:
+                    self.select_range = [self.edit_position, len(self.text)]
+                else:
+                    self.select_range = [0, 0]
+            self.edit_position = len(self.text)
             self.cursor_has_moved_recently = True
             consumed_event = True
         elif event.key == pygame.K_LEFT and event.mod & pygame.KMOD_SHIFT:

--- a/tests/test_elements/test_ui_text_entry_box.py
+++ b/tests/test_elements/test_ui_text_entry_box.py
@@ -775,7 +775,7 @@ class TestUITextEntryBox:
                                   manager=default_ui_manager)
         assert text_box.image is not None
         assert len(text_box.text_box_layout.layout_rows) == 3
-        
+
     def test_rebuild_select_area_1(self, _init_pygame, default_ui_manager,
                                    _display_surface_return_none):
         text_entry = UITextEntryBox(relative_rect=pygame.Rect(100, 100, 200, 30),
@@ -1148,7 +1148,8 @@ class TestUITextEntryBox:
         text_entry.focus()
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 
@@ -1163,7 +1164,8 @@ class TestUITextEntryBox:
         text_entry.focus()
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 
@@ -1177,7 +1179,8 @@ class TestUITextEntryBox:
         assert text_entry.edit_position == 3
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_LEFT}))
+                                                                          {'key': pygame.K_LEFT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.edit_position == 2
@@ -1192,10 +1195,24 @@ class TestUITextEntryBox:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_HOME}))
+                                                                          {'key': pygame.K_HOME,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.select_range == [0, 0]
+        assert text_entry.edit_position == 0
+
+        text_entry.set_text('daniel\nmulti-line\ntext')
+        text_entry.edit_position = 3
+        text_entry.focus()
+        text_entry.select_range = [1, 3]
+
+        processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
+                                                                          {'key': pygame.K_HOME,
+                                                                           'mod': pygame.KMOD_SHIFT}))
+
+        assert processed_key_event
+        assert text_entry.select_range == [0, 1]
         assert text_entry.edit_position == 0
 
     def test_process_event_end(self, _init_pygame: None, default_ui_manager: UIManager,
@@ -1208,11 +1225,25 @@ class TestUITextEntryBox:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_END}))
+                                                                          {'key': pygame.K_END,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.select_range == [0, 0]
         assert text_entry.edit_position == 3
+
+        text_entry.set_text('daniel\nmulti-line\ntext')
+        text_entry.edit_position = 3
+        text_entry.focus()
+        text_entry.select_range = [1, 3]
+
+        processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
+                                                                          {'key': pygame.K_END,
+                                                                           'mod': pygame.KMOD_SHIFT}))
+
+        assert processed_key_event
+        assert text_entry.select_range == [1, len("daniel")]
+        assert text_entry.edit_position == len("daniel")
 
     def test_process_event_text_right_select_range(self, _init_pygame: None,
                                                    default_ui_manager: UIManager,
@@ -1225,7 +1256,8 @@ class TestUITextEntryBox:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 
@@ -1240,7 +1272,8 @@ class TestUITextEntryBox:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_LEFT}))
+                                                                          {'key': pygame.K_LEFT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -651,9 +651,21 @@ class TestUITextEntryLine:
         text_entry.focus()
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
+
+        text_entry.edit_position = 1
+        text_entry.select_range = [1, 3]
+        text_entry.focus()
+
+        processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': pygame.KMOD_SHIFT}))
+        assert processed_key_event
+        assert text_entry.select_range == [2, 3]
+        assert text_entry.edit_position == 2
 
     def test_process_event_text_right_actually_move(self, _init_pygame: None,
                                                     default_ui_manager: UIManager,
@@ -666,7 +678,8 @@ class TestUITextEntryLine:
         text_entry.focus()
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 
@@ -680,7 +693,8 @@ class TestUITextEntryLine:
         assert text_entry.edit_position == 3
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_LEFT}))
+                                                                          {'key': pygame.K_LEFT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.edit_position == 2
@@ -695,7 +709,8 @@ class TestUITextEntryLine:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_HOME}))
+                                                                          {'key': pygame.K_HOME,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.select_range == [0, 0]
@@ -711,11 +726,24 @@ class TestUITextEntryLine:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_END}))
+                                                                          {'key': pygame.K_END,
+                                                                           'mod': 0}))
 
         assert processed_key_event
         assert text_entry.select_range == [0, 0]
         assert text_entry.edit_position == 3
+
+        text_entry.edit_position = 1
+        text_entry.select_range = [1, 3]
+        text_entry.focus()
+
+        processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
+                                                                          {'key': pygame.K_END,
+                                                                           'mod': pygame.KMOD_SHIFT}))
+        assert processed_key_event
+        assert text_entry.select_range == [3, 3]
+        assert text_entry.edit_position == 3
+
 
     def test_process_event_text_right_select_range(self, _init_pygame: None,
                                                    default_ui_manager: UIManager,
@@ -728,7 +756,8 @@ class TestUITextEntryLine:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_RIGHT}))
+                                                                          {'key': pygame.K_RIGHT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 
@@ -743,7 +772,8 @@ class TestUITextEntryLine:
         text_entry.select_range = [0, 2]
 
         processed_key_event = text_entry.process_event(pygame.event.Event(pygame.KEYDOWN,
-                                                                          {'key': pygame.K_LEFT}))
+                                                                          {'key': pygame.K_LEFT,
+                                                                           'mod': 0}))
 
         assert processed_key_event
 


### PR DESCRIPTION
I believe this satisfies https://github.com/MyreMylar/pygame_gui/issues/459.

Two main notes.

1. I'd like to hear whether you agree on changing HOME/END behavior in UITextEntryBox to change to be start/end of current line (to support multi-line text case).

2. Currently, it's possible for my changes to create a situation where `select_range` becomes `[x, x]` for `x != 0`, but my understanding of the intent is that this means no selection and should probably be automatically set to `[0, 0]` in the setter. I wasn't able to get that to work without disrupting other tests, so I'm probably missing additional context. In any case, at least I don't see any new problems created by this situation and the tests pass.