### PR TITLE
the anchor changing

### DIFF
--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -750,20 +750,11 @@ class UIButton(UIElement):
     def _calc_dynamic_size(self):
         if self.dynamic_width or self.dynamic_height:
             self.set_dimensions(self.image.get_size())
-
-            # if we have anchored the left side of our button to the right of its container then
-            # changing the width is going to mess up the horiz position as well.
+            
+            # The following three lines are useless, but there will be an error during initialization after deletion.
+            # For example, the button cannot be clicked
             new_left = self.relative_rect.left
             new_top = self.relative_rect.top
-            if 'left' in self.anchors and self.anchors['left'] == 'right' and self.dynamic_width:
-                left_offset = self.dynamic_dimensions_orig_top_left[0]
-                new_left = left_offset - self.relative_rect.width
-            # if we have anchored the top side of our button to the bottom of it's container then
-            # changing the height is going to mess up the vert position as well.
-            if 'top' in self.anchors and self.anchors['top'] == 'bottom' and self.dynamic_height:
-                top_offset = self.dynamic_dimensions_orig_top_left[1]
-                new_top = top_offset - self.relative_rect.height
-
             self.set_relative_position((new_left, new_top))
 
     def hide(self):

--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -166,20 +166,10 @@ class UILabel(UIElement, IUITextOwnerInterface):
     def _calc_dynamic_size(self):
         if self.dynamic_width or self.dynamic_height:
             self.set_dimensions(self.image.get_size())
-
-            # if we have anchored the left side of our button to the right of its container then
-            # changing the width is going to mess up the horiz position as well.
+            
+            # The following three lines are useless, but there will be an error during initialization after deletion.
             new_left = self.relative_rect.left
             new_top = self.relative_rect.top
-            if 'left' in self.anchors and self.anchors['left'] == 'right' and self.dynamic_width:
-                left_offset = self.dynamic_dimensions_orig_top_left[0]
-                new_left = left_offset - self.relative_rect.width
-            # if we have anchored the top side of our button to the bottom of it's container then
-            # changing the height is going to mess up the vert position as well.
-            if 'top' in self.anchors and self.anchors['top'] == 'bottom' and self.dynamic_height:
-                top_offset = self.dynamic_dimensions_orig_top_left[1]
-                new_top = top_offset - self.relative_rect.height
-
             self.set_relative_position((new_left, new_top))
 
     def rebuild_from_changed_theme_data(self):


### PR DESCRIPTION
Borrowed from Unity's RectTransform and modified the anchor points.

The anchor now consists of a dictionary.

The anchor includes four key value pairs, 'left', 'right', 'top', and 'bottom'. Floating point number, between 0 and 1. 0 indicates anchoring on the left or upper boundary, 1 indicates anchoring on the right or lower boundary, and 0.5 indicates anchoring in the middle.

Add two new values 'pivotx',' pivoty', floating-point numbers between 0 and 1, determines the scaling center of the UI when the size changes. (0, 0) represents the scaling center in the upper left corner, (1, 1) represents the scaling center in the lower right corner (0.5, 0.5) represents the scaling center in the center of the object.

Supports using strings instead of numbers 'left', ' right', ' top', ' bottom', and 'center' represent 0,1, 0,1, and 0.5, respectively.


Principle:

Calculate the anchor rectangle based on the parent container rectangle. 'left', 'right', 'top', and 'bottom' correspond to the percentile of the four sides of the anchored rectangle on the parent container, respectively. When the parent container changes, the anchor rectangle changes accordingly. Keep the distance between the four sides of the element and the four sides of the anchored rectangle fixed and unchanged. So the elements will change with the change of the anchored rectangle. 
When the 'left' and 'right' values of the anchor point are equal, and the 'top' and 'bottom' values are equal, the left and right edges, top and bottom edges of the anchored rectangle coincide, and the anchored rectangle degenerates into an anchor point. At this point, the size of the element does not change with the size of the parent container.
When the size of an element changes, the relative position of its scaling center remains unchanged.

Features:
1. Now the element can anchor the percentile position of the form, for example, left: 0.4, which means anchoring the left side at 40% of the container width.

2. Add a scaling center for the element, which can specify how to move it when the size of the element changes.

3. There is a modification to the annotation. If this modification is made, there is no need to subtract the element width when anchoring the element to the right and bottom.

There may still be some problems in the code. The performance of the code may need attention.

Fixes #505 