### PR TITLE
UITextEntryBox text editing shortcuts into sub functions

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -331,7 +331,8 @@ Fired when a window is resized.
  - **'type'** : pygame_gui.UI_WINDOW_RESIZED,
  - **'ui_element'** : The :class:`UIWindow <pygame_gui.elements.UIWindow>` that fired this event.
  - **'ui_object_id'** : The most unique ID for the element that fired this event.
- - **'size'** : The new size of the window.
+ - **'external_size'** : The total size of the window including title bar, borders & shadows.
+ - **'internal_size'** : The size inside the window where other elements are place (excluding title bar, borders & shadows).
 
 **Example usage**:
 

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -4,6 +4,10 @@ import warnings
 from typing import Union, List, Dict, Optional, Tuple
 
 import pygame
+from pygame import Rect, MOUSEBUTTONDOWN, MOUSEBUTTONUP, BUTTON_LEFT, KEYDOWN, TEXTINPUT
+from pygame import KMOD_SHIFT, KMOD_META, KMOD_CTRL, KMOD_ALT, K_a, K_x, K_c, K_v
+from pygame import K_LEFT, K_RIGHT, K_UP, K_DOWN, K_HOME, K_END, K_BACKSPACE, K_DELETE, K_RETURN
+from pygame import key
 from pygame.event import Event, post
 
 from pygame_gui.core.interfaces.gui_font_interface import IGUIFontInterface

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -4,11 +4,8 @@ import warnings
 from typing import Union, List, Dict, Optional, Tuple
 
 import pygame
-from pygame import Rect, MOUSEBUTTONDOWN, MOUSEBUTTONUP, BUTTON_LEFT, KEYDOWN, TEXTINPUT
-from pygame import KMOD_SHIFT, KMOD_META, KMOD_CTRL, KMOD_ALT, K_a, K_x, K_c, K_v
-from pygame import K_LEFT, K_RIGHT, K_UP, K_DOWN, K_HOME, K_END, K_BACKSPACE, K_DELETE, K_RETURN
-from pygame import key
-from pygame.event import Event, post
+from pygame import KMOD_META, KMOD_CTRL, KMOD_ALT, K_a, K_x, K_c
+from pygame.event import Event
 
 from pygame_gui.core.interfaces.gui_font_interface import IGUIFontInterface
 
@@ -728,7 +725,7 @@ class UITextEntryLine(UIElement):
         if self._process_select_all_event(event):
             consumed_event = True
         elif self._process_cut_event(event):
-            consumed_event = True            
+            consumed_event = True
         elif self._process_copy_event(event):
             consumed_event = True
         elif self._process_paste_event(event):
@@ -747,16 +744,16 @@ class UITextEntryLine(UIElement):
         consumed_event = False
         if (event.key == K_a and
                 (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
-                not (event.mod & KMOD_ALT)):  # hopefully enable diacritic letters)
+                not (event.mod & KMOD_ALT)):  # hopefully enable diacritic letters
             self._do_select_all()
             consumed_event = True
         return consumed_event
 
     def _do_select_all(self):
-        self.select_range = [0, len(self.html_text)]
-        self.edit_position = len(self.html_text)
+        self.select_range = [0, len(self.text)]
+        self.edit_position = len(self.text)
         self.cursor_has_moved_recently = True
-        
+
     def _process_cut_event(self, event: Event) -> bool:
         """
         Process a cut shortcut event. (CTRL+ X)
@@ -768,9 +765,9 @@ class UITextEntryLine(UIElement):
         """
         consumed_event = False
         if (event.key == K_x and
-              (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
-              not self.is_text_hidden and # This is not in UITextEntryBox
-              not (event.mod & KMOD_ALT)):
+                (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
+                not self.is_text_hidden and  # This is not in UITextEntryBox
+                not (event.mod & KMOD_ALT)):
             self._do_cut()
             consumed_event = True
         return consumed_event
@@ -779,15 +776,18 @@ class UITextEntryLine(UIElement):
         if abs(self.select_range[0] - self.select_range[1]) > 0:
             low_end = min(self.select_range[0], self.select_range[1])
             high_end = max(self.select_range[0], self.select_range[1])
-            clipboard_copy(self.html_text[low_end:high_end])
-            self.text_box_layout.delete_selected_text()
+            clipboard_copy(self.text[low_end:high_end])
+            if self.drawable_shape is not None:
+                self.drawable_shape.text_box_layout.delete_selected_text()
+                self.drawable_shape.apply_active_text_changes()
             self.edit_position = low_end
-            self.html_text = self.html_text[:low_end] + self.html_text[high_end:]
-            self.text_box_layout.set_cursor_position(self.edit_position)
+            self.text = self.text[:low_end] + self.text[high_end:]
+            if self.drawable_shape is not None:
+                self.drawable_shape.text_box_layout.set_cursor_position(self.edit_position)
+                self.drawable_shape.apply_active_text_changes()
             self.select_range = [0, 0]
-            self.redraw_from_text_block()
             self.cursor_has_moved_recently = True
-    
+
     def _process_copy_event(self, event: Event) -> bool:
         """
         Process a copy shortcut event. (CTRL+ C)
@@ -799,9 +799,9 @@ class UITextEntryLine(UIElement):
         """
         consumed_event = False
         if (event.key == K_c and
-              (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
-              not self.is_text_hidden and #This line is not in UITextEntryBoox
-              not (event.mod & KMOD_ALT)):
+                (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
+                not self.is_text_hidden and  # This line is not in UITextEntryBox
+                not (event.mod & KMOD_ALT)):
             self._do_copy()
             consumed_event = True
         return consumed_event
@@ -810,7 +810,7 @@ class UITextEntryLine(UIElement):
         if abs(self.select_range[0] - self.select_range[1]) > 0:
             low_end = min(self.select_range[0], self.select_range[1])
             high_end = max(self.select_range[0], self.select_range[1])
-            clipboard_copy(self.html_text[low_end:high_end])
+            clipboard_copy(self.text[low_end:high_end])
 
     def _process_paste_event(self, event: pygame.event.Event) -> bool:
         """

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Union, List, Dict, Optional, Tuple
 
 import pygame
+from pygame.event import Event, post
 
 from pygame_gui.core.interfaces.gui_font_interface import IGUIFontInterface
 

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -720,44 +720,92 @@ class UITextEntryLine(UIElement):
 
         """
         consumed_event = False
-        if (event.key == pygame.K_a and
-                (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META) and
-                not (event.mod & pygame.KMOD_ALT)):  # hopefully enable diacritic letters
-            self.select_range = [0, len(self.text)]
-            self.edit_position = len(self.text)
-            self.cursor_has_moved_recently = True
+        if self._process_select_all_event(event):
             consumed_event = True
-        elif (event.key == pygame.K_x and
-              (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META) and
-              not self.is_text_hidden and
-              not (event.mod & pygame.KMOD_ALT)):  # hopefully enable diacritic letters
-            if abs(self.select_range[0] - self.select_range[1]) > 0:
-                low_end = min(self.select_range[0], self.select_range[1])
-                high_end = max(self.select_range[0], self.select_range[1])
-                clipboard_copy(self.text[low_end:high_end])
-                if self.drawable_shape is not None:
-                    self.drawable_shape.text_box_layout.delete_selected_text()
-                    self.drawable_shape.apply_active_text_changes()
-                self.edit_position = low_end
-                self.text = self.text[:low_end] + self.text[high_end:]
-                if self.drawable_shape is not None:
-                    self.drawable_shape.text_box_layout.set_cursor_position(self.edit_position)
-                    self.drawable_shape.apply_active_text_changes()
-                self.select_range = [0, 0]
-                self.cursor_has_moved_recently = True
-                consumed_event = True
-        elif (event.key == pygame.K_c and
-              (event.mod & pygame.KMOD_CTRL or event.mod & pygame.KMOD_META) and
-              not self.is_text_hidden and
-              not (event.mod & pygame.KMOD_ALT)):  # hopefully enable diacritic letters:
-            if abs(self.select_range[0] - self.select_range[1]) > 0:
-                low_end = min(self.select_range[0], self.select_range[1])
-                high_end = max(self.select_range[0], self.select_range[1])
-                clipboard_copy(self.text[low_end:high_end])
-                consumed_event = True
+        elif self._process_cut_event(event):
+            consumed_event = True            
+        elif self._process_copy_event(event):
+            consumed_event = True
         elif self._process_paste_event(event):
             consumed_event = True
         return consumed_event
+
+    def _process_select_all_event(self, event: Event) -> bool:
+        """
+        Process a select all shortcut event. (CTRL+ A)
+
+        :param event: The event to process.
+
+        :return: True if the event is consumed.
+
+        """
+        consumed_event = False
+        if (event.key == K_a and
+                (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
+                not (event.mod & KMOD_ALT)):  # hopefully enable diacritic letters)
+            self._do_select_all()
+            consumed_event = True
+        return consumed_event
+
+    def _do_select_all(self):
+        self.select_range = [0, len(self.html_text)]
+        self.edit_position = len(self.html_text)
+        self.cursor_has_moved_recently = True
+        
+    def _process_cut_event(self, event: Event) -> bool:
+        """
+        Process a cut shortcut event. (CTRL+ X)
+
+        :param event: The event to process.
+
+        :return: True if the event is consumed.
+
+        """
+        consumed_event = False
+        if (event.key == K_x and
+              (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
+              not self.is_text_hidden and # This is not in UITextEntryBox
+              not (event.mod & KMOD_ALT)):
+            self._do_cut()
+            consumed_event = True
+        return consumed_event
+
+    def _do_cut(self):
+        if abs(self.select_range[0] - self.select_range[1]) > 0:
+            low_end = min(self.select_range[0], self.select_range[1])
+            high_end = max(self.select_range[0], self.select_range[1])
+            clipboard_copy(self.html_text[low_end:high_end])
+            self.text_box_layout.delete_selected_text()
+            self.edit_position = low_end
+            self.html_text = self.html_text[:low_end] + self.html_text[high_end:]
+            self.text_box_layout.set_cursor_position(self.edit_position)
+            self.select_range = [0, 0]
+            self.redraw_from_text_block()
+            self.cursor_has_moved_recently = True
+    
+    def _process_copy_event(self, event: Event) -> bool:
+        """
+        Process a copy shortcut event. (CTRL+ C)
+
+        :param event: The event to process.
+
+        :return: True if the event is consumed.
+
+        """
+        consumed_event = False
+        if (event.key == K_c and
+              (event.mod & KMOD_CTRL or event.mod & KMOD_META) and
+              not self.is_text_hidden and #This line is not in UITextEntryBoox
+              not (event.mod & KMOD_ALT)):
+            self._do_copy()
+            consumed_event = True
+        return consumed_event
+
+    def _do_copy(self):
+        if abs(self.select_range[0] - self.select_range[1]) > 0:
+            low_end = min(self.select_range[0], self.select_range[1])
+            high_end = max(self.select_range[0], self.select_range[1])
+            clipboard_copy(self.html_text[low_end:high_end])
 
     def _process_paste_event(self, event: pygame.event.Event) -> bool:
         """

--- a/tests/test_elements/test_ui_window.py
+++ b/tests/test_elements/test_ui_window.py
@@ -81,7 +81,6 @@ class TestUIWindow:
                                         window.get_container().rect.top + 10)
         assert button.rect.topright == (374, 253)
 
-                                
         window.set_dimensions((300, 400))
 
         assert button.rect.topright == (window.get_container().rect.right - 10,
@@ -90,15 +89,19 @@ class TestUIWindow:
         
         confirm_event_fired = False
         event_object_id = None
+        new_external_dimensions = (0, 0)
+        new_internal_dimensions = (0, 0)
         for event in pygame.event.get():
             if (event.type == pygame_gui.UI_WINDOW_RESIZED and
                     event.ui_element == window):
                 confirm_event_fired = True
                 event_object_id = event.ui_object_id
-                new_dimensions = event.size
+                new_external_dimensions = event.external_size
+                new_internal_dimensions = event.internal_size
         assert confirm_event_fired
         assert event_object_id == 'window'
-        assert new_dimensions == (300, 400)
+        assert new_external_dimensions == (300, 400)
+        assert new_internal_dimensions == (268, 341)
 
     def test_set_relative_position(self, _init_pygame, default_ui_manager: IUIManagerInterface,
                                    _display_surface_return_none):


### PR DESCRIPTION
I'm looking to implement some basic text edit functionality within the UITextEntryBox (cut, copy, paste, etc.) and apply it to buttons, like in a menu bar. The UITextEntryBox has all the functionality already, however it is all in one function _process_keyboard_shortcut_event() and tied to keyboard controls.

This proposed change splits the code for Select All, Cut, and Copy into a more extensible format. This format was modeled after how Paste works, with a _process_paste_event() function to check for the correct keyboard process and handled the consumed event, and another function _do_paste() to execute the shortcut. I've split all three other shortcuts into the same format.

If you like this change, I'll add the tests and the documentation before the merge - I think that should be all of it? Let me know if you have any other thoughts! Thanks!