### PR TITLE
System font fallback

### DIFF
--- a/docs/source/localization.rst
+++ b/docs/source/localization.rst
@@ -45,18 +45,23 @@ Default supported languages
 
 Right now the list of languages support by default by Pygame GUI elements and windows is:
 
+ - Arabic
  - German
  - English
  - Spanish
  - French
+ - Georgian
+ - Hebrew
  - Indonesian
  - Italian
  - Japanese
+ - Korean
+ - Polish
  - Portuguese
  - Russian
- - Simplified Chinese
- - Polish
+ - Ukrainian
  - Vietnamese
+ - Simplified Chinese
 
 Though many of the translations may be imperfect as they were largely not handled by native speakers (yet). If you
 would like to improve an existing translation or add a new one the current default translations are

--- a/docs/source/pygame_gui.core.rst
+++ b/docs/source/pygame_gui.core.rst
@@ -8,6 +8,7 @@ Subpackages
 
    pygame_gui.core.drawable_shapes
    pygame_gui.core.interfaces
+   pygame_gui.core.text
 
 Submodules
 ----------
@@ -28,6 +29,38 @@ pygame\_gui.core.colour\_parser module
    :no-undoc-members:
    :show-inheritance:
 
+pygame\_gui.core.gui\_font\_pygame module
+--------------------------------------
+
+.. automodule:: pygame_gui.core.gui_font_pygame
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.core.layered\_gui\_group module
+--------------------------------------
+
+.. automodule:: pygame_gui.core.layered_gui_group
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.core.object\_id module
+--------------------------------------
+
+.. automodule:: pygame_gui.core.object_id
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.core.resource\_loaders module
+--------------------------------------
+
+.. automodule:: pygame_gui.core.resource_loaders
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 pygame\_gui.core.surface\_cache module
 --------------------------------------
 
@@ -40,6 +73,14 @@ pygame\_gui.core.ui\_appearance\_theme module
 ---------------------------------------------
 
 .. automodule:: pygame_gui.core.ui_appearance_theme
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.core.ui\_container module
+---------------------------------------------
+
+.. automodule:: pygame_gui.core.ui_container
    :members:
    :no-undoc-members:
    :show-inheritance:

--- a/docs/source/pygame_gui.elements.rst
+++ b/docs/source/pygame_gui.elements.rst
@@ -4,6 +4,22 @@ pygame\_gui.elements package
 Submodules
 ----------
 
+pygame\_gui.elements.ui\_2d\_slider module
+--------------------------------------
+
+.. automodule:: pygame_gui.elements.ui_2d_slider
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.elements.ui\_auto\_resizing\_container module
+--------------------------------------
+
+.. automodule:: pygame_gui.elements.auto_resizing_container
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 pygame\_gui.elements.ui\_button module
 --------------------------------------
 
@@ -16,6 +32,14 @@ pygame\_gui.elements.ui\_drop\_down\_menu module
 ------------------------------------------------
 
 .. automodule:: pygame_gui.elements.ui_drop_down_menu
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.elements.ui\_horizontal\_scroll\_bar module
+--------------------------------------------------
+
+.. automodule:: pygame_gui.elements.ui_horizontal_scroll_bar
    :members:
    :no-undoc-members:
    :show-inheritance:
@@ -68,6 +92,14 @@ pygame\_gui.elements.ui\_screen\_space\_health\_bar module
    :no-undoc-members:
    :show-inheritance:
 
+pygame\_gui.elements.ui\_scrolling\_container module
+-----------------------------------------------
+
+.. automodule:: pygame_gui.elements.ui_scrolling_container
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
 pygame\_gui.elements.ui\_selection\_list module
 -----------------------------------------------
 
@@ -88,6 +120,14 @@ pygame\_gui.elements.ui\_text\_box module
 -----------------------------------------
 
 .. automodule:: pygame_gui.elements.ui_text_box
+   :members:
+   :no-undoc-members:
+   :show-inheritance:
+
+pygame\_gui.elements.ui\_text\_entry\_box module
+-------------------------------------------------
+
+.. automodule:: pygame_gui.elements.ui_text_entry_box
    :members:
    :no-undoc-members:
    :show-inheritance:

--- a/tests/test_core/test_ui_font_dictionary.py
+++ b/tests/test_core/test_ui_font_dictionary.py
@@ -59,7 +59,10 @@ class TestUIFontDictionary:
     def test_find_font_unloaded(self, _init_pygame, _display_surface_return_none):
         font_dictionary = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
 
-        font_dictionary.find_font(font_size=20, font_name='arial')
+        # try genuine (for match font) & nonsense
+        font_dictionary.find_font(font_size=20, font_name='sans')
+
+        font_dictionary.find_font(font_size=20, font_name='nonsense_adhawdw')
 
     def test_create_font_id(self, _init_pygame, _display_surface_return_none):
         font_dictionary = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
@@ -85,8 +88,11 @@ class TestUIFontDictionary:
 
     def test_preload_no_paths(self, _init_pygame, _display_surface_return_none):
         font_dictionary = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        # test probably universally valid system font
+        font_dictionary.preload_font(font_name='sans', font_size=14)
+
         with pytest.warns(UserWarning, match="Trying to pre-load font id"):
-            font_dictionary.preload_font(font_name='arial', font_size=14)
+            font_dictionary.preload_font(font_name='nonsense_adhawdw', font_size=14)
 
     def test_preload_bad_paths(self, _init_pygame, _display_surface_return_none):
         loader = BlockingThreadedResourceLoader()

--- a/tests/test_core/test_ui_font_dictionary.py
+++ b/tests/test_core/test_ui_font_dictionary.py
@@ -61,6 +61,9 @@ class TestUIFontDictionary:
 
         # try genuine (for match font) & nonsense
         font_dictionary.find_font(font_size=20, font_name='sans')
+        font_dictionary.find_font(font_size=20, font_name='sans', bold=True, italic=True)
+        font_dictionary.find_font(font_size=20, font_name='sans', bold=True, italic=False)
+        font_dictionary.find_font(font_size=20, font_name='sans', bold=False, italic=True)
 
         font_dictionary.find_font(font_size=20, font_name='nonsense_adhawdw')
 
@@ -90,6 +93,9 @@ class TestUIFontDictionary:
         font_dictionary = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
         # test probably universally valid system font
         font_dictionary.preload_font(font_name='sans', font_size=14)
+        font_dictionary.preload_font(font_size=20, font_name='sans', bold=True, italic=True)
+        font_dictionary.preload_font(font_size=20, font_name='sans', bold=True, italic=False)
+        font_dictionary.preload_font(font_size=20, font_name='sans', bold=False, italic=True)
 
         with pytest.warns(UserWarning, match="Trying to pre-load font id"):
             font_dictionary.preload_font(font_name='nonsense_adhawdw', font_size=14)

--- a/tests/test_core/test_ui_font_dictionary.py
+++ b/tests/test_core/test_ui_font_dictionary.py
@@ -61,9 +61,14 @@ class TestUIFontDictionary:
 
         # try genuine (for match font) & nonsense
         font_dictionary.find_font(font_size=20, font_name='sans')
-        font_dictionary.find_font(font_size=20, font_name='sans', bold=True, italic=True)
-        font_dictionary.find_font(font_size=20, font_name='sans', bold=True, italic=False)
-        font_dictionary.find_font(font_size=20, font_name='sans', bold=False, italic=True)
+        font_dictionary_2 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_2.find_font(font_size=20, font_name='sans', bold=True, italic=True)
+
+        font_dictionary_3 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_3.find_font(font_size=20, font_name='sans', bold=True, italic=False)
+
+        font_dictionary_4 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_4.find_font(font_size=20, font_name='sans', bold=False, italic=True)
 
         font_dictionary.find_font(font_size=20, font_name='nonsense_adhawdw')
 
@@ -93,9 +98,15 @@ class TestUIFontDictionary:
         font_dictionary = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
         # test probably universally valid system font
         font_dictionary.preload_font(font_name='sans', font_size=14)
-        font_dictionary.preload_font(font_size=20, font_name='sans', bold=True, italic=True)
-        font_dictionary.preload_font(font_size=20, font_name='sans', bold=True, italic=False)
-        font_dictionary.preload_font(font_size=20, font_name='sans', bold=False, italic=True)
+
+        font_dictionary_2 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_2.preload_font(font_size=20, font_name='sans', bold=True, italic=True)
+
+        font_dictionary_3 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_3.preload_font(font_size=20, font_name='sans', bold=True, italic=False)
+
+        font_dictionary_4 = UIFontDictionary(BlockingThreadedResourceLoader(), locale='en')
+        font_dictionary_4.preload_font(font_size=20, font_name='sans', bold=False, italic=True)
 
         with pytest.warns(UserWarning, match="Trying to pre-load font id"):
             font_dictionary.preload_font(font_name='nonsense_adhawdw', font_size=14)


### PR DESCRIPTION
When asking for a font that can't be found in pygame gui's preloaded fonts, the font dictionary will now fallback to using pygame's system font search to find a font on the user's system.

fixes #468