### PR TITLE
Overlapping visible UI elements: handle detection and events in the correct order

### DIFF
--- a/pygame_gui/core/layered_gui_group.py
+++ b/pygame_gui/core/layered_gui_group.py
@@ -289,4 +289,4 @@ class LayeredGUIGroup(LayeredUpdates):
         """
         self.visible = [spr.blit_data
                         for spr in self._spritelist
-                        if spr.image is not None and spr.visible]
+                        if spr.image is not None and spr.visible][::-1]


### PR DESCRIPTION
When multiple visible UI elements overlap, process mouse detection and event handling in the correct order so the top element receives events and detection as expected. Fixes #609.
