### PR TITLE
Fix disabled UITextBox no hover cursor #604

### DIFF
--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -558,7 +558,7 @@ class UITextBox(UIElement, IUITextOwnerInterface):
                 self.redraw_from_text_block()
 
         scaled_mouse_pos = self.ui_manager.get_mouse_position()
-        if self.hovered:
+        if self.hovered and self.is_enabled:
             if (self.scroll_bar is None or
                     (self.scroll_bar is not None and
                      not self.scroll_bar.hover_point(scaled_mouse_pos[0], scaled_mouse_pos[1]))):

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -328,7 +328,7 @@ class UITextEntryLine(UIElement):
         if not self.alive():
             return
         scaled_mouse_pos = self.ui_manager.get_mouse_position()
-        if self.hovered:
+        if self.hovered and self.is_enabled:
             self.ui_manager.set_text_hovered(True)
 
         if self.double_click_timer < self.ui_manager.get_double_click_time():


### PR DESCRIPTION
This fixes issue #604, which occurs when a UITextBox widget is disabled, yet hovering over it changes to the text-select cursor, incorrectly implying that the widget text can be selected.