### PR TITLE
Fix #610 by not hiding if not visible

### DIFF
--- a/pygame_gui/elements/ui_button.py
+++ b/pygame_gui/elements/ui_button.py
@@ -804,9 +804,9 @@ class UIButton(UIElement):
         """
         In addition to the base UIElement.hide() - Change the hovered state to a normal state.
         """
-        super().hide()
-
-        self.on_unhovered()
+        if self.visible:
+            super().hide()
+            self.on_unhovered()
 
     def on_locale_changed(self):
         font = self.ui_theme.get_font(self.combined_element_ids)

--- a/pygame_gui/elements/ui_drop_down_menu.py
+++ b/pygame_gui/elements/ui_drop_down_menu.py
@@ -629,6 +629,9 @@ class UIClosedDropDownState:
         """
         Hide selected_option_button and open_button.
         """
+        if not self.visible:
+            return
+
         self.visible = False
 
         if self.open_button is not None:
@@ -1013,6 +1016,9 @@ class UIDropDownMenu(UIContainer):
         hide() method, which begins a transition of the UIDropDownMenu to the 'closed' state, and
         call the hide() method of the 'closed' state which hides all it's children widgets.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self.current_state is not None and self.menu_states is not None:
             if self.current_state == self.menu_states['expanded']:

--- a/pygame_gui/elements/ui_horizontal_scroll_bar.py
+++ b/pygame_gui/elements/ui_horizontal_scroll_bar.py
@@ -613,6 +613,9 @@ class UIHorizontalScrollBar(UIElement):
         In addition to the base UIElement.hide() - hide the self.button_container which
         will propagate and hide all the buttons.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self.button_container is not None:
             self.button_container.hide()

--- a/pygame_gui/elements/ui_horizontal_slider.py
+++ b/pygame_gui/elements/ui_horizontal_slider.py
@@ -567,6 +567,9 @@ class UIHorizontalSlider(UIElement):
         In addition to the base UIElement.hide() - hide the sliding button and hide
         the button_container which will propagate and hide the left and right buttons.
         """
+        if not self.visible:
+            return
+
         super().hide()
 
         if self.sliding_button is not None:

--- a/pygame_gui/elements/ui_panel.py
+++ b/pygame_gui/elements/ui_panel.py
@@ -299,6 +299,9 @@ class UIPanel(UIElement, IContainerLikeInterface):
         """
         In addition to the base UIElement.hide() - call hide() of owned container - panel_container.
         """
+        if not self.visible:
+            return
+
         if self.panel_container is not None:
             self.panel_container.hide()
         super().hide()

--- a/pygame_gui/elements/ui_scrolling_container.py
+++ b/pygame_gui/elements/ui_scrolling_container.py
@@ -531,6 +531,9 @@ class UIScrollingContainer(UIElement, IContainerLikeInterface):
         it's visibility will propagate to them - there is no need to call their hide() methods
         separately.
         """
+        if not self.visible:
+            return
+
         if self._root_container is not None:
             self._root_container.hide()
         super().hide()

--- a/pygame_gui/elements/ui_selection_list.py
+++ b/pygame_gui/elements/ui_selection_list.py
@@ -728,6 +728,9 @@ class UISelectionList(UIElement):
         children of list_and_scroll_bar_container, so it's visibility will propagate to them -
         there is no need to call their hide() methods separately.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self.list_and_scroll_bar_container is not None:
             self.list_and_scroll_bar_container.hide()

--- a/pygame_gui/elements/ui_tab_container.py
+++ b/pygame_gui/elements/ui_tab_container.py
@@ -183,6 +183,9 @@ class UITabContainer(UIElement):
         In addition to the base UIElement.hide() - hide the _window_root_container which will
         propagate and hide all the children.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self._root_container is not None:
             self._root_container.hide()

--- a/pygame_gui/elements/ui_text_box.py
+++ b/pygame_gui/elements/ui_text_box.py
@@ -1221,6 +1221,9 @@ class UITextBox(UIElement, IUITextOwnerInterface):
         """
         In addition to the base UIElement.hide() - call hide() of scroll_bar if it exists.
         """
+        if not self.visible:
+            return
+
         super().hide()
 
         if self.scroll_bar is not None:

--- a/pygame_gui/elements/ui_vertical_scroll_bar.py
+++ b/pygame_gui/elements/ui_vertical_scroll_bar.py
@@ -609,6 +609,9 @@ class UIVerticalScrollBar(UIElement):
         In addition to the base UIElement.hide() - hide the self.button_container which will
         propagate and hide all the buttons.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self.button_container is not None:
             self.button_container.hide()

--- a/pygame_gui/elements/ui_window.py
+++ b/pygame_gui/elements/ui_window.py
@@ -764,6 +764,9 @@ class UIWindow(UIElement, IContainerLikeInterface, IWindowInterface):
         In addition to the base UIElement.hide() - hide the _window_root_container which will
         propagate and hide all the children.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self._window_root_container is not None:
             self._window_root_container.hide()

--- a/pygame_gui/windows/ui_colour_picker_dialog.py
+++ b/pygame_gui/windows/ui_colour_picker_dialog.py
@@ -286,6 +286,9 @@ class UIColourChannelEditor(UIElement):
         In addition to the base UIElement.hide() - call hide() of the element_container
         - which will propagate to the sub-elements - label, entry and slider.
         """
+        if not self.visible:
+            return
+
         super().hide()
         if self.element_container is not None:
             self.element_container.hide()


### PR DESCRIPTION
This fixes issue #610, where calling the `hide()` method on an already hidden element called the full `hide()` functionality again, including generating any events, such as unhovering. This bug is present in all `hide()`  method implementation in the codebase (except `UIPanel.hide`) and is fixed with this commit for all widgets, by exiting the `hide()`  method early if `self.visible` is `False`.