### PR TITLE
Bump version and add testing for python 3.13

### DIFF
--- a/.github/workflows/run_tests_ci.yml
+++ b/.github/workflows/run_tests_ci.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        pygame-ce-version: ['2.4.0']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        pygame-ce-version: ['2.5.2']
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
         pygame-ce-version: ${{ matrix.pygame-ce-version }}
@@ -37,7 +37,7 @@ jobs:
       run: |
         xvfb-run pytest --cov-report=xml --cov=pygame_gui tests/
     - name: Upload to Code Cov
-      uses: codecov/codecov-action@v4.3.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }} #required
 
@@ -47,12 +47,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ '3.11','3.12' ]
-        pygame-ce-version: [ '2.4.0' ]
+        python-version: [ '3.12','3.13' ]
+        pygame-ce-version: [ '2.5.2' ]
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
           pygame-ce-version: ${{ matrix.pygame-ce-version }}
@@ -73,7 +73,7 @@ jobs:
         run: |
           pytest --cov-report=xml --cov=pygame_gui tests/
       - name: Upload to Code Cov
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }} #required
 
@@ -83,12 +83,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ '3.11', '3.12' ]
-        pygame-ce-version: [ '2.3.2' ]
+        python-version: [ '3.12', '3.13' ]
+        pygame-ce-version: [ '2.5.2' ]
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
           pygame-ce-version: ${{ matrix.pygame-ce-version }}
@@ -109,6 +109,6 @@ jobs:
         run: |
           pytest --cov-report=xml --cov=pygame_gui tests/
       - name: Upload to Code Cov
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }} #required

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A GUI system for pygame CE.
 ## Requirements
 
  - Python 3.8+
- - Pygame Community Edition 2.4.0+
+ - Pygame Community Edition 2.5.2+
  - python-i18n (does localization to different languages)
 
 ## How to install

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,9 +34,9 @@ copyright = '2019, Dan Lawrence'
 author = 'Dan Lawrence'
 
 # The short X.Y version
-version = '0.6.12'
+version = '0.6.13'
 # The full version, including alpha/beta/rc tags
-release = '0.6.12'
+release = '0.6.13'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
       name='pygame_gui',
-      version='0.6.12',
+      version='0.6.13',
       description='A GUI module for pygame Community Edition',
       long_description="Helps create GUIs for games made using pygame Community Edition. "
                        "Features HTML-style text formatting, localization,"
@@ -11,7 +11,7 @@ setup(
                        " multiple windows of GUI stuff.",
       keywords=["pygame", "gui", "ui"],
       url='https://github.com/MyreMylar/pygame_gui',
-      download_url='https://github.com/MyreMylar/pygame_gui/archive/v_0612.tar.gz',
+      download_url='https://github.com/MyreMylar/pygame_gui/archive/v_0613.tar.gz',
       author='Dan Lawrence',
       author_email='danintheshed@gmail.com',
       license='MIT',
@@ -29,7 +29,7 @@ setup(
       zip_safe=False,
       python_requires='>=3.8',
       setup_requires=[],
-      install_requires=['pygame-ce>=2.4.0',
+      install_requires=['pygame-ce>=2.5.2',
                         'python-i18n>=0.3.9',
                         'importlib_resources>1.3; python_version < "3.9"'],
       include_package_data=True,


### PR DESCRIPTION
Bump library main branch version in preparation for release, update pygame-ce version to 3.13 supporting version and add testing for 3.13.

May also drop support for python 3.8 in the next release as it will uncomplicate some code, but that will be a separate PR.