### PR TITLE
Fix: Replace 'relative_rect' with 'rel_rect' in UILabel.__init__

### DIFF
--- a/pygame_gui/elements/ui_label.py
+++ b/pygame_gui/elements/ui_label.py
@@ -64,7 +64,7 @@ class UILabel(UIElement, IUITextOwnerInterface):
                          object_id=object_id,
                          element_id=['label'])
 
-        self.dynamic_dimensions_orig_top_left = relative_rect.topleft
+        self.dynamic_dimensions_orig_top_left = rel_rect.topleft
 
         self.text = text
         self.text_kwargs = {}


### PR DESCRIPTION
`UILabel.__init__` made use of the parameter `relative_rect` to position the UI element, instead of the local variable `rel_rect`. This prevented `UILabel` elements from being initialized with a coordinate instead of a `Rect`-like.

This is a fix for Issue #657.