### PR TITLE
If UITextEntryLine.is_text_hidden is True, replacing text now doesn't reveal the text (and added a unit test)

### DIFF
--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -641,7 +641,10 @@ class UITextEntryLine(UIElement):
         self.text = self.text[:low_end] + character + self.text[high_end:]
 
         if self.drawable_shape is not None:
-            self.drawable_shape.set_text(self.text)
+            if not self.is_text_hidden:
+                self.drawable_shape.set_text(self.text)
+            else:
+                self.drawable_shape.set_text(self.hidden_text_char * len(self.text))
         self.edit_position = low_end + 1
         self.select_range = [0, 0]
 

--- a/pygame_gui/elements/ui_text_entry_line.py
+++ b/pygame_gui/elements/ui_text_entry_line.py
@@ -242,6 +242,10 @@ class UITextEntryLine(UIElement):
         characters and also disallow copying the text into the clipboard. It is designed
         for basic 'password box' usage.
 
+        .. Warning:: Prior to version 0.6.14, there is a bug in which replacing highlighted
+                     sections of text would reveal the text that was previously hidden. Use older
+                     versions for security-sensitive applications at your own risk!
+
         :param is_hidden: Can be set to True or False. Defaults to True because
                           if you are calling this you likely want a password box with no fuss.
                           Set it back to False if you want to un-hide the text (e.g.

--- a/tests/test_elements/test_ui_text_entry_line.py
+++ b/tests/test_elements/test_ui_text_entry_line.py
@@ -1191,6 +1191,25 @@ class TestUITextEntryLine:
 
         assert text_entry.get_text() == "Some basic text"
 
+    def test_internal_replace_selection_with_entered_character(
+        self, _init_pygame, default_ui_manager, _display_surface_return_none
+    ):
+        resolution = (400, 200)
+        manager = UIManager(resolution)
+        text_entry = UITextEntryLine(
+            relative_rect=pygame.Rect(100, 80, 200, 30), manager=manager
+        )
+
+        text_entry.set_text_hidden(True)
+        text_entry.set_text("password")
+        text_entry.select_range = [0, 2]
+        text_entry._replace_selection_with_entered_character("d")
+
+        assert text_entry.drawable_shape.theming["text"] == (
+            text_entry.hidden_text_char * 7
+        )
+        assert text_entry.text == "dssword"
+
 
 if __name__ == '__main__':
     pytest.console_main()


### PR DESCRIPTION
Reproducer script
```python3
import pygame
import pygame_gui

pygame.init()

# Set up display
window_size = (400, 200)
window = pygame.display.set_mode(window_size)
pygame.display.set_caption("Minimal Password Field")

# Manager
ui_manager = pygame_gui.UIManager(window_size)

# Password input field
password_input = pygame_gui.elements.UITextEntryLine(
    relative_rect=pygame.Rect((100, 80), (200, 30)),
    manager=ui_manager
)
password_input.set_text_hidden(True)  # Hides text like a password field

clock = pygame.time.Clock()
is_running = True

# Game loop
while is_running:
    time_delta = clock.tick(60) / 1000.0  # In seconds

    for event in pygame.event.get():
        if event.type == pygame.QUIT:
            is_running = False

        ui_manager.process_events(event)

    ui_manager.update(time_delta)

    window.fill((0, 0, 0))  # Clear screen
    ui_manager.draw_ui(window)

    pygame.display.update()

pygame.quit()
```
Broken behavior recording
https://github.com/user-attachments/assets/93a952f5-c0de-434e-9f8a-962df45f756b

Reported [here](https://discord.com/channels/772505616680878080/921096717871501342/1374942850739081287) in the PGC discord