### PR TITLE
Fixed broken JSON in theme guide

### DIFF
--- a/docs/source/theme_guide.rst
+++ b/docs/source/theme_guide.rst
@@ -473,12 +473,12 @@ Here's a quick example of using a simple prototype:
          }
       },
 
-      "button"
+      "button":
       {
          "prototype": "#new_shape_style"
       },
 
-      "horizontal_slider"
+      "horizontal_slider":
       {
          "prototype": "#new_shape_style",
          "misc":


### PR DESCRIPTION
I was reading the documentation for theme configuration [here](https://pygame-gui.readthedocs.io/en/latest/theme_guide.html), and noticed that the JSON in the "Theme Prototypes" section was broken. This fixes it; two colons were missing.