### PR TITLE
Initialize pygame.font if it's not already initialized

### DIFF
--- a/pygame_gui/ui_manager.py
+++ b/pygame_gui/ui_manager.py
@@ -162,6 +162,8 @@ class UIManager(IUIManagerInterface):
         translation_directory_paths: Optional[List[str]] = None,
     ):
         super().__init__()
+        if (not pygame.font.get_init()):
+            pygame.font.init()
         if get_default_manager() is None:
             set_default_manager(self)
         # Translation stuff

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -527,6 +527,13 @@ class TestUIManager:
 
         assert manager.get_hovering_any_element()
 
+    def test_font_init_internal(self, _init_pygame, _display_surface_return_none):
+        if pygame.font.get_init():
+            pygame.font.quit()
+
+        manager = UIManager((800, 800))
+        assert pygame.font.get_init()
+
 
 if __name__ == "__main__":
     os.chdir("..")


### PR DESCRIPTION
Fix the underlying issue that led to #719 when trying to load fonts